### PR TITLE
Improving config metadata parsing

### DIFF
--- a/main/src/main/java/de/blinkt/openvpn/core/ConfigParser.java
+++ b/main/src/main/java/de/blinkt/openvpn/core/ConfigParser.java
@@ -53,7 +53,7 @@ public class ConfigParser {
                     throw new ConfigParseError("Input looks like a ZIP Archive. Import is only possible for OpenVPN config files (.ovpn/.conf)");
 
                 // Check for OpenVPN Access Server Meta information
-                if (line.startsWith("# OVPN_ACCESS_SERVER_")) {
+                if(line.matches("^#(\\s+)?OVPN_ACCESS_SERVER_.*")) {
                     Vector<String> metaarg = parsemeta(line);
                     meta.put(metaarg.get(0), metaarg);
                     continue;
@@ -81,12 +81,17 @@ public class ConfigParser {
     }
 
     private Vector<String> parsemeta(String line) {
-        String meta = line.split("#\\sOVPN_ACCESS_SERVER_", 2)[1];
-        String[] parts = meta.split("=", 2);
+        String meta = line.split("OVPN_ACCESS_SERVER_", 2)[1];
+        String[] parts = meta.split("=",2);
+        
+        //trimming
+        for(int i=0; i<parts.length; i++) {
+            parts[i] = parts[i].trim();
+        }
+        
         Vector<String> rval = new Vector<String>();
         Collections.addAll(rval, parts);
         return rval;
-
     }
 
     private void checkinlinefile(Vector<String> args, BufferedReader br) throws IOException, ConfigParseError {


### PR DESCRIPTION
Allowing using spaces on the settings:

```
#OVPN_ACCESS_SERVER_SETNAME=1
# OVPN_ACCESS_SERVER_SETNAME=1
# OVPN_ACCESS_SERVER_SETNAME = 1
etc...
```
