### PR TITLE
fixes missing space

### DIFF
--- a/main/src/main/java/de/blinkt/openvpn/core/VpnStatus.java
+++ b/main/src/main/java/de/blinkt/openvpn/core/VpnStatus.java
@@ -226,7 +226,7 @@ public class VpnStatus {
 				} else {
 					String str = String.format(Locale.ENGLISH,"Log (no context) resid %d", mRessourceId);
 					if(mArgs !=null)
-						str += TextUtils.join("|", mArgs);
+						str += " " + TextUtils.join("|", mArgs);
 
 
 					return str;


### PR DESCRIPTION
current log:

```
[Apr 26, 14:04:27] [INFO] Log (no context) resid 213155856910.7.1.1|null
```

after the fixes:

```
```

[Apr 26, 14:04:27] [INFO] Log (no context) resid 2131558569 10.7.1.1|null

```
```
