### PR TITLE
Added LEVEL_REFUSED as a new connection status.

### DIFF
--- a/main/src/main/java/de/blinkt/openvpn/core/OpenVPNService.java
+++ b/main/src/main/java/de/blinkt/openvpn/core/OpenVPNService.java
@@ -218,6 +218,7 @@ public class OpenVPNService extends VpnService implements StateListener, Callbac
             case LEVEL_AUTH_FAILED:
             case LEVEL_NONETWORK:
             case LEVEL_NOTCONNECTED:
+            case LEVEL_REFUSED:
                 return R.drawable.ic_stat_vpn_offline;
             case LEVEL_CONNECTING_NO_SERVER_REPLY_YET:
             case LEVEL_WAITING_FOR_USER_INPUT:

--- a/main/src/main/java/de/blinkt/openvpn/core/OpenVPNThread.java
+++ b/main/src/main/java/de/blinkt/openvpn/core/OpenVPNThread.java
@@ -179,7 +179,13 @@ public class OpenVPNThread implements Runnable {
 
                     VpnStatus.logMessageOpenVPN(logStatus,logLevel,msg);
                 } else {
-                    VpnStatus.logInfo("P:" + logline);
+					// Connection refused by server.
+					if (logline.matches("^.*?(ECONNREFUSED|Connection refused).*$")){
+						VpnStatus.updateStateString("ECONNREJECTED", "Connection refused by server.", R.string.state_refused, ConnectionStatus.LEVEL_REFUSED);
+						// Do not reconnect to refused server
+						mService.getManagement().stopVPN();
+					}
+					VpnStatus.logInfo("P:" + logline);
                 }
 			}
 			

--- a/main/src/main/java/de/blinkt/openvpn/core/VpnStatus.java
+++ b/main/src/main/java/de/blinkt/openvpn/core/VpnStatus.java
@@ -137,6 +137,7 @@ public class VpnStatus {
         LEVEL_START,
         LEVEL_AUTH_FAILED,
         LEVEL_WAITING_FOR_USER_INPUT,
+        LEVEL_REFUSED,
         UNKNOWN_LEVEL
     }
 

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -246,6 +246,7 @@
     <string name="state_reconnecting">Reconnecting</string>
     <string name="state_exiting">Exiting</string>
     <string name="state_noprocess">Not running</string>
+    <string name="state_refused">Connection was refused</string>
     <string name="state_resolve">Resolving host names</string>
     <string name="state_tcp_connect">Connecting (TCP)</string>
     <string name="state_auth_failed">Authentication failed</string>


### PR DESCRIPTION
In case if a server went down while either UDP or TCP connection is established, you'll get `read UDP [ECONNREFUSED]: Connection refused (code=111)` (UDP) or `TCP connect to [AF_INET]<IP>:<PORT> failed: Connection refused`. I thought it would be good to handle this state. that's what it is all about.

Here's a small patch for ics-openvpn which introduces a new connection state `LEVEL_REFUSED`. 
I've hardcoded `stopVPN()` if the connection is refused because connecting to a server which is refusing your connection doesn't make sense for me.

@schwabe what do you think?
