### PR TITLE
Vpn stop management issues

### DIFF
--- a/main/src/main/java/de/blinkt/openvpn/core/OpenVPNService.java
+++ b/main/src/main/java/de/blinkt/openvpn/core/OpenVPNService.java
@@ -500,6 +500,10 @@ public class OpenVPNService extends VpnService implements StateListener, Callbac
             }
         }
 
+        forceStopOpenVpnProcess();
+    }
+
+    public void forceStopOpenVpnProcess() {
         synchronized (mProcessLock) {
             if (mProcessThread != null) {
                 mProcessThread.interrupt();

--- a/main/src/main/java/de/blinkt/openvpn/core/OpenVPNThread.java
+++ b/main/src/main/java/de/blinkt/openvpn/core/OpenVPNThread.java
@@ -180,10 +180,12 @@ public class OpenVPNThread implements Runnable {
                 } else {
                     VpnStatus.logInfo("P:" + logline);
                 }
+
+                if (Thread.interrupted()) {
+                    throw new InterruptedException("OpenVpn process was killed form java code");
+                }
             }
-
-
-        } catch (IOException e) {
+        } catch (InterruptedException | IOException e) {
             VpnStatus.logException("Error reading from output of OpenVPN process", e);
             stopProcess();
         }


### PR DESCRIPTION
There are some issues in vpn stop mechanisms:
1. OpenVpn thread doesn't respect Java thread interruption
2.  OpenVpnManagementThread  posting any state updates after `stopVPN()` have been called, regardless of actual SIGINT command have been sent

This PR fixed both issues
