### PR TITLE
Fix windows 'build-native.bat'

### DIFF
--- a/main/misc/build-native.bat
+++ b/main/misc/build-native.bat
@@ -48,7 +48,7 @@ if [%1] == [] (
 
 if not errorlevel 0 goto error
 
-rmdir /Q /S ovpnlibs
+if exist ovpnlibs rmdir /Q /S ovpnlibs
 
 cd libs
 mkdir ..\ovpnlibs

--- a/main/misc/build-native.bat
+++ b/main/misc/build-native.bat
@@ -41,9 +41,9 @@ if not exist openvpn\.git (
 )
 
 if [%1] == [] (
-    ndk-build USE_SHORT_COMMANDS=1 -j 8 USE_BREAKPAD=0
+    call ndk-build USE_SHORT_COMMANDS=1 -j 8 USE_BREAKPAD=0
 ) else (
-    ndk-build USE_SHORT_COMMANDS=1 %*
+    call ndk-build USE_SHORT_COMMANDS=1 %*
 )
 
 if not errorlevel 0 goto error


### PR DESCRIPTION
`opvnlibs\assets` and `opvnlibs\jniLibs` created properly after building native binaries