### PR TITLE
Fix rare crash with LogFragment

### DIFF
--- a/main/src/main/java/de/blinkt/openvpn/fragments/LogFragment.java
+++ b/main/src/main/java/de/blinkt/openvpn/fragments/LogFragment.java
@@ -503,13 +503,16 @@ public class LogFragment extends ListFragment implements StateListener, SeekBar.
     @Override
     public void onResume() {
         super.onResume();
-        VpnStatus.addStateListener(this);
-        VpnStatus.addByteCountListener(this);
         Intent intent = new Intent(getActivity(), OpenVPNService.class);
         intent.setAction(OpenVPNService.START_SERVICE);
-
     }
 
+    @Override
+    public void onStart() {
+        super.onStart();
+        VpnStatus.addStateListener(this);
+        VpnStatus.addByteCountListener(this);
+    }
 
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {


### PR DESCRIPTION
The status listeners are registered in `onResume()`, but are unregistered in `onStop()`.
The fragment crashed in our app when I opened it, selected the reconnect VPN option from the menu, closed the activity, and reopened the log activity again.
It would crash at line 121, where it would request `getActivity().getResources()`, but the activity would be null.
