### PR TITLE
Screen off pause criteria settings

### DIFF
--- a/main/src/main/java/de/blinkt/openvpn/core/DeviceStateReceiver.java
+++ b/main/src/main/java/de/blinkt/openvpn/core/DeviceStateReceiver.java
@@ -30,9 +30,9 @@ public class DeviceStateReceiver extends BroadcastReceiver implements ByteCountL
     private OpenVPNManagement mManagement;
 
     // Window time in s
-    private final int TRAFFIC_WINDOW = 60;
+    private int TRAFFIC_WINDOW = 60;
     // Data traffic limit in bytes
-    private final long TRAFFIC_LIMIT = 64 * 1024;
+    private long TRAFFIC_LIMIT = 64 * 1024;
 
     // Time to wait after network disconnect to pause the VPN
     private final int DISCONNECT_WAIT = 20;
@@ -138,6 +138,8 @@ public class DeviceStateReceiver extends BroadcastReceiver implements ByteCountL
     public void onReceive(Context context, Intent intent) {
         SharedPreferences prefs = Preferences.getDefaultSharedPreferences(context);
 
+        TRAFFIC_WINDOW = Integer.parseInt(prefs.getString("screenofftime", "60"));
+        TRAFFIC_LIMIT = Integer.parseInt(prefs.getString("screenofftransfer", "64")) * 1024;
 
         if (ConnectivityManager.CONNECTIVITY_ACTION.equals(intent.getAction())) {
             networkStateChange(context);

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -465,5 +465,8 @@
     <string name="all_app_prompt">An external app tries to control %s. The app requesting access cannot be determined. Allowing this app grants ALL apps access.</string>
     <string name="openvpn3_nostatickeys">The OpenVPN 3 C++ implementation does not support static keys. Please change to OpenVPN 2.x under general settings.</string>
     <string name="openvpn3_pkcs12">Using PKCS12 files directly with OpenVPN 3 C++ implementation is not supported. Please import the pkcs12 files into the Android keystore or change to OpenVPN 2.x under general settings.</string>
-
+    <string name="screenofftimetitle">Screen Off Timeout (in seconds)</string>
+    <string name="screenofftimedesc">Time to wait after the screen turns off before pausing the VPN (default 60 seconds)</string>
+    <string name="screenofftransfertitle">Screen Off Max Transfer (in KB)</string>
+    <string name="screenofftransferdesc">Maximum amount of data allowed to be transferred while screen is off to allow the VPN to pause (default 64KB)</string>
 </resources>

--- a/main/src/main/res/xml/general_settings.xml
+++ b/main/src/main/res/xml/general_settings.xml
@@ -60,7 +60,16 @@
                 android:key="screenoff"
                 android:summary="@string/screenoff_summary"
                 android:title="@string/screenoff_title"/>
-
+        <EditTextPreference
+            android:defaultValue="60"
+            android:title="@string/screenofftimetitle"
+            android:summary="@string/screenofftimedesc"
+            android:key="screenofftime"/>
+        <EditTextPreference
+            android:defaultValue="64"
+            android:title="@string/screenofftransfertitle"
+            android:summary="@string/screenofftransferdesc"
+            android:key="screenofftransfer"/>
         <Preference
                 android:dependency=""
             android:key="osslspeed"


### PR DESCRIPTION
This PR adds two new settings options: Screen Off Timeout and Screen Off Max Transfer.

This allows the user to customize how long their screen can be off for before the VPN is automatically paused to save power.

It also lets them customize how much data can be sent before the VPN is automatically paused to save power.

The main reason for the latter is, even at idle, the amount of data an Android phone will use goes up with time, so 64KB might not be enough if the user sets, say, 30min.

Settings are in English, but should be relatively simple to translate (It's about a total of 4 sentences).