### PR TITLE
Fixing a typo on full license

### DIFF
--- a/main/src/main/assets/full_licenses.html
+++ b/main/src/main/assets/full_licenses.html
@@ -11,7 +11,7 @@ with the following clarification/additional terms of what constitues "deriviate 
 
 <p>Using/including any part of ics-openvpn, especially using/including any part of the
 de.blinkt.openvpn class hierarchy, creates derivative work of ics-openvpn.
-Aadditionally, the normal definitions of derivative work apply.</p>
+Additionally, the normal definitions of derivative work apply.</p>
 
 <p>  Special exception for linking ics-openvpn with OpenSSL:</p>
 


### PR DESCRIPTION
"Aadditionally" -> "Additionally"