### PR TITLE
Launch main activity when long pressing quick tile

### DIFF
--- a/main/src/main/AndroidManifest.xml
+++ b/main/src/main/AndroidManifest.xml
@@ -59,6 +59,9 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE_PREFERENCES"/>
+            </intent-filter>
         </activity>
 
         <service


### PR DESCRIPTION
By default, long pressing a quick tile will open the "App info" page for the app. This handles the appropriate intent to instead launch the main activity.