### PR TITLE
Add option to allow apps to bypass VPN

### DIFF
--- a/main/src/main/java/de/blinkt/openvpn/VpnProfile.java
+++ b/main/src/main/java/de/blinkt/openvpn/VpnProfile.java
@@ -142,6 +142,7 @@ public class VpnProfile implements Serializable, Cloneable {
     public boolean mRemoteRandom = false;
     public HashSet<String> mAllowedAppsVpn = new HashSet<>();
     public boolean mAllowedAppsVpnAreDisallowed = true;
+    public boolean mAllowAppVpnBypass = false;
     public String mCrlFilename;
     public String mProfileCreator;
     public String mExternalAuthenticator;

--- a/main/src/main/java/de/blinkt/openvpn/core/OpenVPNService.java
+++ b/main/src/main/java/de/blinkt/openvpn/core/OpenVPNService.java
@@ -979,6 +979,11 @@ public class OpenVPNService extends VpnService implements StateListener, Callbac
         } else {
             VpnStatus.logDebug(R.string.allowed_vpn_apps_info, TextUtils.join(", ", mProfile.mAllowedAppsVpn));
         }
+
+        if (mProfile.mAllowAppVpnBypass) {
+            builder.allowBypass();
+            VpnStatus.logDebug("Apps may bypass VPN");
+        }
     }
 
     public void addDNS(String dns) {

--- a/main/src/main/java/de/blinkt/openvpn/fragments/Settings_Allowed_Apps.java
+++ b/main/src/main/java/de/blinkt/openvpn/fragments/Settings_Allowed_Apps.java
@@ -46,6 +46,7 @@ public class Settings_Allowed_Apps extends Fragment implements AdapterView.OnIte
     private ListView mListView;
     private VpnProfile mProfile;
     private TextView mDefaultAllowTextView;
+    private TextView mAllowBypassTextView;
     private PackageAdapter mListAdapter;
 
     @Override
@@ -304,6 +305,7 @@ public class Settings_Allowed_Apps extends Fragment implements AdapterView.OnIte
         View v = inflater.inflate(R.layout.allowed_vpn_apps, container, false);
 
         mDefaultAllowTextView = (TextView) v.findViewById(R.id.default_allow_text);
+        mAllowBypassTextView = (TextView) v.findViewById(R.id.allow_bypass_text);
 
         Switch vpnOnDefaultSwitch = (Switch) v.findViewById(R.id.default_allow);
 
@@ -317,6 +319,17 @@ public class Settings_Allowed_Apps extends Fragment implements AdapterView.OnIte
         });
 
         vpnOnDefaultSwitch.setChecked(mProfile.mAllowedAppsVpnAreDisallowed);
+
+        Switch vpnAllowBypassSwitch = (Switch) v.findViewById(R.id.allow_bypass);
+
+        vpnAllowBypassSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                mProfile.mAllowAppVpnBypass = isChecked;
+            }
+        });
+
+        vpnAllowBypassSwitch.setChecked(mProfile.mAllowAppVpnBypass);
 
         mListView = (ListView) v.findViewById(android.R.id.list);
 
@@ -341,5 +354,7 @@ public class Settings_Allowed_Apps extends Fragment implements AdapterView.OnIte
             mDefaultAllowTextView.setText(R.string.vpn_disallow_radio);
         else
             mDefaultAllowTextView.setText(R.string.vpn_allow_radio);
+
+        mAllowBypassTextView.setText(R.string.vpn_allow_bypass);
     }
 }

--- a/main/src/main/res/layout/allowed_vpn_apps.xml
+++ b/main/src/main/res/layout/allowed_vpn_apps.xml
@@ -37,6 +37,33 @@
             android:layout_height="wrap_content" />
         </RelativeLayout>
 
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:minHeight="?android:attr/actionBarSize"
+        android:background="@drawable/bg_switchbar"
+        android:paddingStart="@dimen/switchbar_pad"
+        android:elevation="1dp"
+        android:paddingEnd="@dimen/switchbar_pad"
+        tools:ignore="NewApi">
+
+        <Switch
+            android:id="@+id/allow_bypass"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+             />
+        <TextView
+            android:id="@+id/allow_bypass_text"
+            style="@android:style/TextAppearance.Medium.Inverse"
+            tools:text="@string/vpn_allow_bypass"
+            android:layout_toStartOf="@id/allow_bypass"
+            android:layout_width="wrap_content"
+            android:layout_centerVertical="true"
+            android:layout_height="wrap_content" />
+        </RelativeLayout>
+
     <ListView
         android:visibility="gone"
         android:id="@android:id/list"

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -335,6 +335,7 @@
     <string name="app_no_longer_exists">Package %s is no longer installed, removing it from app allow/disallow list</string>
     <string name="vpn_disallow_radio">VPN is used for all apps but exclude selected</string>
     <string name="vpn_allow_radio">VPN is used for only for selected apps</string>
+    <string name="vpn_allow_bypass">Allow apps to bypass the VPN</string>
     <string name="query_delete_remote">Remove remote server entry?</string>
     <string name="keep">Keep</string>
     <string name="delete">Delete</string>


### PR DESCRIPTION
I added an option to the "Allowed Apps" configuration to allow apps to explicitly bypass the VPN using ConnectivityManager.bindProcessToNetwork(Network) or Network.bindSocket(Socket).

Checking this setting causes OpenVPNService to call VpnService.Builder.allowBypass().