### PR TITLE
Add toggle to disable the need for unlocking a device to toggle vpn tile

### DIFF
--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -329,6 +329,7 @@
     <string name="mssfix_dialogtitle">Set MSS of TCP payload</string>
     <string name="client_behaviour">Client behaviour</string>
     <string name="clear_external_apps">Clear allowed external apps</string>
+    <string name="requireunlockfortile">Require unlock to toggle QS Tile</string>
     <string name="loading">Loading…</string>
     <string name="allowed_vpn_apps_info">Allowed VPN apps: %1$s</string>
     <string name="disallowed_vpn_apps_info">Disallowed VPN apps: %1$s</string>

--- a/main/src/ui/java/de/blinkt/openvpn/OpenVPNTileService.java
+++ b/main/src/ui/java/de/blinkt/openvpn/OpenVPNTileService.java
@@ -11,6 +11,7 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.ServiceConnection;
+import android.content.SharedPreferences;
 import android.os.Build;
 import android.os.IBinder;
 import android.os.RemoteException;
@@ -21,6 +22,7 @@ import android.widget.Toast;
 import de.blinkt.openvpn.core.ConnectionStatus;
 import de.blinkt.openvpn.core.IOpenVPNServiceInternal;
 import de.blinkt.openvpn.core.OpenVPNService;
+import de.blinkt.openvpn.core.Preferences;
 import de.blinkt.openvpn.core.ProfileManager;
 import de.blinkt.openvpn.core.VpnStatus;
 
@@ -40,7 +42,10 @@ public class OpenVPNTileService extends TileService implements VpnStatus.StateLi
         if (bootProfile == null) {
             Toast.makeText(this, R.string.novpn_selected, Toast.LENGTH_SHORT).show();
         } else {
-            if (!isLocked())
+            SharedPreferences prefs = Preferences.getDefaultSharedPreferences(getBaseContext());
+            boolean requireUnlockForTile = prefs.getBoolean("requireunlockfortile", true);
+
+            if (!isLocked() || !requireUnlockForTile)
                 clickAction(bootProfile);
             else
                 unlockAndRun(new Runnable() {

--- a/main/src/ui/res/xml/general_settings.xml
+++ b/main/src/ui/res/xml/general_settings.xml
@@ -39,6 +39,11 @@
                 android:key="clearapi"
                 android:persistent="false"
                 android:title="@string/clear_external_apps"/>
+
+        <CheckBoxPreference
+                android:defaultValue="true"
+                android:key="requireunlockfortile"
+                android:title="@string/requireunlockfortile"/>
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/vpnbehaviour">


### PR DESCRIPTION
* Defaults to "true" (require an unlock to toggle the tile). When disabled
  a user can toggle the VPN tile regardless of if the device has been
  unlocked.