### PR TITLE
Fix for MDM in case ovpn field is one line

### DIFF
--- a/main/src/main/java/de/blinkt/openvpn/api/AppRestrictions.java
+++ b/main/src/main/java/de/blinkt/openvpn/api/AppRestrictions.java
@@ -149,7 +149,22 @@ public class AppRestrictions {
 
     }
 
+    private String prepare(String config) {
+        String newLine = System.getProperty("line.separator");
+        if (!config.contains(newLine)&& !config.contains(" ")) {
+            try {
+                byte[] decoded = android.util.Base64.decode(config.getBytes(), android.util.Base64.DEFAULT);
+                config  = new String(decoded);
+                return config; 
+            } catch(IllegalArgumentException e) {
+               
+            }
+        }
+        return config;
+    };
+    
     private void addProfile(Context c, String config, String uuid, String name, VpnProfile vpnProfile) {
+        config  = prepare(config);
         ConfigParser cp = new ConfigParser();
         try {
             cp.parseConfig(new StringReader(config));


### PR DESCRIPTION
Fix for MDM which support appconfig (in case ovpn field is one line base64 encoded string).

If config contains only one line without spaces, then:
- If not exception is cought, then it is a decoded base64 string
- If exception is cought, then assumed it is a normal string