### PR TITLE
Fix MDM restriction check for G Suite

### DIFF
--- a/main/src/main/java/de/blinkt/openvpn/api/AppRestrictions.java
+++ b/main/src/main/java/de/blinkt/openvpn/api/AppRestrictions.java
@@ -149,7 +149,22 @@ public class AppRestrictions {
 
     }
 
+    private String prepare(String config) {
+        String newLine = System.getProperty("line.separator");
+        if (!config.contains(newLine)&& !config.contains(" ")) {
+            try {
+                byte[] decoded = android.util.Base64.decode(config.getBytes(), android.util.Base64.DEFAULT);
+                config  = new String(decoded);
+                return config; 
+            } catch(IllegalArgumentException e) {
+               
+            }
+        }
+        return config;
+    };
+    
     private void addProfile(Context c, String config, String uuid, String name, VpnProfile vpnProfile) {
+        config  = prepare(config);
         ConfigParser cp = new ConfigParser();
         try {
             cp.parseConfig(new StringReader(config));

--- a/main/src/main/java/de/blinkt/openvpn/api/AppRestrictions.java
+++ b/main/src/main/java/de/blinkt/openvpn/api/AppRestrictions.java
@@ -85,11 +85,12 @@ public class AppRestrictions {
             if (Integer.parseInt(configVersion) != CONFIG_VERSION)
                 throw new NumberFormatException("Wrong version");
         } catch (NumberFormatException nex) {
-            if ("(not set)".equals(configVersion))
+            if ("(not set)".equals(configVersion)) {
                 // Ignore error if no version present
+            } else {                
+                VpnStatus.logError(String.format(Locale.US, "App restriction version %s does not match expected version %d", configVersion, CONFIG_VERSION));
                 return;
-            VpnStatus.logError(String.format(Locale.US, "App restriction version %s does not match expected version %d", configVersion, CONFIG_VERSION));
-            return;
+            }
         }
         Parcelable[] profileList = restrictions.getParcelableArray(("vpn_configuration_list"));
         if (profileList == null) {

--- a/main/src/main/java/de/blinkt/openvpn/api/AppRestrictions.java
+++ b/main/src/main/java/de/blinkt/openvpn/api/AppRestrictions.java
@@ -85,12 +85,11 @@ public class AppRestrictions {
             if (Integer.parseInt(configVersion) != CONFIG_VERSION)
                 throw new NumberFormatException("Wrong version");
         } catch (NumberFormatException nex) {
-            if ("(not set)".equals(configVersion)) {
+            if ("(not set)".equals(configVersion))
                 // Ignore error if no version present
-            } else {                
-                VpnStatus.logError(String.format(Locale.US, "App restriction version %s does not match expected version %d", configVersion, CONFIG_VERSION));
                 return;
-            }
+            VpnStatus.logError(String.format(Locale.US, "App restriction version %s does not match expected version %d", configVersion, CONFIG_VERSION));
+            return;
         }
         Parcelable[] profileList = restrictions.getParcelableArray(("vpn_configuration_list"));
         if (profileList == null) {


### PR DESCRIPTION
In case of Google Play EMM API iFrame which used by G Suite mdm (from Google) configVersion value equals to "(not set)".
fix to prevent creation of new profile need to check for configVersion:
- in case of "(not set)", then ignore error of no version present
- else app resctriction version does not match expected version