### PR TITLE
Change provider authority reference to include applicationId

### DIFF
--- a/main/src/ui/AndroidManifest.xml
+++ b/main/src/ui/AndroidManifest.xml
@@ -160,7 +160,7 @@
 
         <provider
                 android:name=".FileProvider"
-                android:authorities="de.blinkt.openvpn.FileProvider"
+                android:authorities="${applicationId}.FileProvider"
                 android:exported="true"
                 android:grantUriPermissions="true"
                 tools:ignore="ExportedContentProvider" />


### PR DESCRIPTION
We have found an issue that we couldn't install any of our apps next to each other, and also next to the official OpenVPN for Android app.
The reason is that the provider authorities must be unique globally on the device. Since the class name is hardcoded, it will be the same for all of the implementors of this library.
Although this issue can be easily fixed by changing this manually, I think it is important to do it, because it might be missed by most developers, since we usually do not test 2 VPN apps next to each other. By doing this change, the authority will always start with the final application package ID, so it should be unique globally.