### PR TITLE
Ability to pass extras when starting VPN via AIDL using inline config

### DIFF
--- a/main/src/main/aidl/de/blinkt/openvpn/api/IOpenVPNAPIService.aidl
+++ b/main/src/main/aidl/de/blinkt/openvpn/api/IOpenVPNAPIService.aidl
@@ -63,4 +63,8 @@ interface IOpenVPNAPIService {
 
     /** Use a profile with all certificates etc. embedded */
     APIVpnProfile addNewVPNProfile (String name, boolean userEditable, String config);
+
+    /** Same as startVPN(String), but also takes a Bundle with extra parameters,
+    * which will be applied to the created VPNProfile (e.g. allow vpn bypass). */
+    void startVPNwithExtras(in String inlineconfig, in Bundle extras);
 }

--- a/main/src/main/java/de/blinkt/openvpn/api/ExternalOpenVPNService.java
+++ b/main/src/main/java/de/blinkt/openvpn/api/ExternalOpenVPNService.java
@@ -20,6 +20,7 @@ import android.content.pm.PackageManager.NameNotFoundException;
 import android.net.VpnService;
 import android.os.Binder;
 import android.os.Build;
+import android.os.Bundle;
 import android.os.Handler;
 import android.os.IBinder;
 import android.os.Message;
@@ -49,6 +50,8 @@ import de.blinkt.openvpn.core.VpnStatus.StateListener;
 public class ExternalOpenVPNService extends Service implements StateListener {
 
     private static final int SEND_TOALL = 0;
+
+    private static final String EXTRA_INLINE_PROFILE_ALLOW_VPN_BYPASS = "de.blinkt.openvpn.api.ALLOW_VPN_BYPASS";
 
     final RemoteCallbackList<IOpenVPNStatusCallback> mCallbacks =
             new RemoteCallbackList<>();
@@ -161,7 +164,8 @@ public class ExternalOpenVPNService extends Service implements StateListener {
             startProfile(vp);
         }
 
-        public void startVPN(String inlineConfig) throws RemoteException {
+        @Override
+        public void startVPNwithExtras(String inlineConfig, Bundle extras) throws RemoteException {
             String callingApp = mExtAppDb.checkOpenVPNPermission(getPackageManager());
 
             ConfigParser cp = new ConfigParser();
@@ -173,6 +177,10 @@ public class ExternalOpenVPNService extends Service implements StateListener {
                     throw new RemoteException(getString(vp.checkProfile(getApplicationContext())));
 
                 vp.mProfileCreator = callingApp;
+
+                if (extras != null) {
+                    vp.mAllowAppVpnBypass = extras.getBoolean(EXTRA_INLINE_PROFILE_ALLOW_VPN_BYPASS, false);
+                }
 
                 /*int needpw = vp.needUserPWInput(false);
                 if(needpw !=0)
@@ -188,6 +196,10 @@ public class ExternalOpenVPNService extends Service implements StateListener {
             }
         }
 
+        @Override
+        public void startVPN(String inlineConfig) throws RemoteException {
+            startVPNwithExtras(inlineConfig, null);
+        }
 
         @Override
         public boolean addVPNProfile(String name, String config) throws RemoteException {


### PR DESCRIPTION
Because AIDL doesn't support method overloads, to preserve backward compatibility, a new method is added: IOpenVPNAPIService#startVPNwithExtras(String, Bundle).

Currently only one extra parameter is supported: `de.blinkt.openvpn.api.ALLOW_VPN_BYPASS`. 

Resolves #1341