### PR TITLE
Fix build and finding symbol

### DIFF
--- a/main/src/skeleton/java/de/blinkt/openvpn/core/VariantConfig.java
+++ b/main/src/skeleton/java/de/blinkt/openvpn/core/VariantConfig.java
@@ -9,7 +9,7 @@ import android.content.Context;
 import android.content.Intent;
 
 public class VariantConfig {
-    static Intent getOpenUrlIntent(Context c, bool external) {
+    static Intent getOpenUrlIntent(Context c, boolean external) {
         return new Intent(Intent.ACTION_VIEW);
     }
 


### PR DESCRIPTION
ics-openvpn/main/src/skeleton/java/de/blinkt/openvpn/core/VariantConfig.java:12: error: cannot find symbol
    static Intent getOpenUrlIntent(Context c, bool external) {
                                              ^
  symbol:   class bool
  location: class de.blinkt.openvpn.core.VariantConfig
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
1 error

FAILURE: Build failed with an exception.