### PR TITLE
Fix NPE when resuming VPN activity

### DIFF
--- a/main/src/ui/java/de/blinkt/openvpn/activities/MainActivity.java
+++ b/main/src/ui/java/de/blinkt/openvpn/activities/MainActivity.java
@@ -79,7 +79,8 @@ public class MainActivity extends BaseActivity {
         super.onResume();
         Intent intent = getIntent();
         if (intent != null) {
-            if (intent.getAction().equals(Intent.ACTION_VIEW))
+            String action = intent.getAction();
+            if (action != null && Intent.ACTION_VIEW.equals(action))
             {
                 Uri uri = intent.getData();
                 checkUriForProfileImport(uri);


### PR DESCRIPTION
Fixes: Implement support of openvpn://import-profile/ support

E AndroidRuntime: FATAL EXCEPTION: main
E AndroidRuntime: Process: de.blinkt.openvpn, PID: 15364
E AndroidRuntime: java.lang.RuntimeException: Unable to resume activity
{de.blinkt.openvpn/de.blinkt.openvpn.activities.MainActivity}: java.lang.NullPointerException:
Attempt to invoke virtual method 'boolean java.lang.String.equals(java.lang.Object)' on a null object reference
E AndroidRuntime: 	at android.app.ActivityThread.performResumeActivity(ActivityThread.java:3454)
E AndroidRuntime: 	at android.app.ActivityThread.handleResumeActivity(ActivityThread.java:3494)
E AndroidRuntime: 	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2757)
E AndroidRuntime: 	at android.app.ActivityThread.-wrap12(ActivityThread.java)
E AndroidRuntime: 	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1496)
E AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:102)
E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:154)
E AndroidRuntime: 	at android.app.ActivityThread.main(ActivityThread.java:6186)
E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
E AndroidRuntime: 	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:889)
E AndroidRuntime: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:779)
E AndroidRuntime: Caused by: java.lang.NullPointerException: Attempt to invoke virtual method
'boolean java.lang.String.equals(java.lang.Object)' on a null object reference
E AndroidRuntime: 	at de.blinkt.openvpn.activities.MainActivity.onResume(MainActivity.java:82)
E AndroidRuntime: 	at android.app.Instrumentation.callActivityOnResume(Instrumentation.java:1270)
E AndroidRuntime: 	at android.app.Activity.performResume(Activity.java:6788)
E AndroidRuntime: 	at android.app.ActivityThread.performResumeActivity(ActivityThread.java:3431)
E AndroidRuntime: 	... 10 more