### PR TITLE
Update doc for getSignedDataWithExtra function

### DIFF
--- a/main/src/main/aidl/de/blinkt/openvpn/api/ExternalCertificateProvider.aidl
+++ b/main/src/main/aidl/de/blinkt/openvpn/api/ExternalCertificateProvider.aidl
@@ -38,19 +38,31 @@ interface ExternalCertificateProvider {
     Bundle getCertificateMetaData(in String alias);
 
     /**
-     * Requests signing the data with RSA/ECB/PKCS1PADDING or RSA/ECB/nopadding
+     * Requests signing the data with RSA/ECB/nopadding, RSA/ECB/PKCS1PADDING or PKCS1PSSPADDING
      * for RSA certficate and with NONEwithECDSA for EC certificates
      * @param alias user certificate identifier
      * @param data the data to be signed
      * @param extra additional information.
      * Should contain the following keys:
-     * <p><ul>
+     * <ul>
        * <li>int key "de.blinkt.openvpn.api.RSA_PADDING_TYPE", may be set as:
-       * <p><ul>
+       * <ul>
          * <li>0 - for RSA/ECB/nopadding
          * <li>1 - for RSA/ECB/PKCS1PADDING
-         * </ul><p>
-       * </ul><p>
+         * <li>2 - for PKCS1PSSPADDING
+       * </ul>
+       * <li>string key "de.blinkt.openvpn.api.SALTLEN", may be set as:
+       * <ul>
+         * <li>"digest" - use the same salt size as the hash to sign
+         * <li>"max" - use maximum possible saltlen which is '(nbits-1)/8 - hlen - 2'. Here
+           * 'nbits' is the number of bits in the key modulus and 'hlen' is the size in octets of
+           * the hash. See: RFC 8017 sec 8.1.1 and 9.1.1.
+       * </ul>
+       * <li>boolean key "de.blinkt.openvpn.api.NEEDS_DIGEST", indicating that the data should be
+         * hashed before signing or not
+       * <li>string key "de.blinkt.openvpn.api.DIGEST", the short common digest algorithm name to
+         * use (such as SHA256, SHA224, etc.)
+     * </ul>
      */
     byte[] getSignedDataWithExtra(in String alias, in byte[] data, in Bundle extra);
 }


### PR DESCRIPTION
After adding pss padding support the javadoc for getSignedDataWithExtra
function in ExternalCertificateProvider.aidl was not updated.