### PR TITLE
Consolidate and align project dependencies via version catalog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,25 +3,7 @@
  * Distributed under the GNU GPL v2 with additional terms. For full terms see the file doc/LICENSE.txt
  */
 
-
-buildscript {
-    var kotlin_version: String by extra
-
-    kotlin_version = "1.9.0"
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath("com.android.tools.build:gradle:8.1.1")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-        maven(url = "https://jitpack.io")
-    }
+plugins {
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.kotlin.android) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,39 +1,51 @@
 [versions]
-kotlin = "1.9.0"
-constraintlayout = "2.1.4"
-cardview = "1.0.0"
-recyclerview = "1.3.0"
-appcompat = "1.6.1"
-mpandroidchart = "v3.1.0"
-okhttp = "4.10.0"
-core-ktx = "1.10.1"
-fragment-ktx = "1.6.0"
-preference-ktx = "1.2.0"
-material = "1.7.0"
+android-gradle-plugin = "8.1.1"
+androidx-annotation = "1.6.0"
+androidx-appcompat = "1.6.1"
+android-view-material = "1.7.0"
+androidx-core-ktx = "1.10.1"
+androidx-fragment-ktx = "1.6.0"
+androidx-preference-ktx = "1.2.0"
 androidx-webkit = "1.7.0"
 androidx-lifecycle-viewmodel-ktx = "2.6.1"
 androidx-lifecycle-runtime-ktx = "2.6.1"
 androidx-security-crypto = "1.1.0-alpha06"
-androidx-annotation = "1.6.0"
-android-gradle-plugin = "8.1.1"
+androidx-constraintlayout = "2.1.4"
+androidx-cardview = "1.0.0"
+androidx-recyclerview = "1.3.0"
+mpandroidchart = "v3.1.0"
+kotlin = "1.9.0"
+square-okhttp = "4.10.0"
+
+# Test
+androidx-test-core = "1.4.0"
+junit = "4.13.2"
+mockito-core = "3.9.0"
+robolectric = "4.10.2"
 
 [libraries]
-kotlin = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
-androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
-androidx-cardview = { group = "androidx.cardview", name = "cardview", version.ref = "cardview" }
-androidx-recyclerview = { group = "androidx.recyclerview", name = "recyclerview", version.ref = "recyclerview" }
-androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
-mpandroidchart = { group = "com.github.PhilJay", name = "MPAndroidChart", version.ref = "mpandroidchart" }
-square-okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
-androidx-core-ktx = { group = "androidx.core", name = "core", version.ref = "core-ktx" }
-androidx-fragment-ktx = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "fragment-ktx" }
-androidx-preference-ktx = { group = "androidx.preference", name = "preference-ktx", version.ref = "preference-ktx" }
-material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+android-view-material = { group = "com.google.android.material", name = "material", version.ref = "android-view-material" }
+androidx-annotation = { group = "androidx.annotation", name = "annotation", version.ref = "androidx-annotation" }
+androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidx-appcompat" }
+androidx-cardview = { group = "androidx.cardview", name = "cardview", version.ref = "androidx-cardview" }
+androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "androidx-constraintlayout" }
+androidx-core-ktx = { group = "androidx.core", name = "core", version.ref = "androidx-core-ktx" }
+androidx-fragment-ktx = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "androidx-fragment-ktx" }
+androidx-preference-ktx = { group = "androidx.preference", name = "preference-ktx", version.ref = "androidx-preference-ktx" }
 androidx-webkit = { group = "androidx.webkit", name = "webkit", version.ref = "androidx-webkit" }
 androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle-viewmodel-ktx" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "androidx-lifecycle-runtime-ktx" }
+androidx-recyclerview = { group = "androidx.recyclerview", name = "recyclerview", version.ref = "androidx-recyclerview" }
 androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "androidx-security-crypto" }
-androidx-annotation = { group = "androidx.annotation", name = "annotation", version.ref = "androidx-annotation" }
+mpandroidchart = { group = "com.github.PhilJay", name = "MPAndroidChart", version.ref = "mpandroidchart" }
+kotlin = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
+square-okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "square-okhttp" }
+
+# Test
+androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidx-test-core" }
+junit = { group = "junit", name = "junit", version.ref = "junit" }
+mockito-core = { group = "org.mockito", name = "mockito-core", version.ref = "mockito-core" }
+robolectric = { group = "org.robolectric:robolectric:4.10.2", name = "robolectric", version.ref = "robolectric" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "android-gradle-plugin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,40 @@
+[versions]
+kotlin = "1.9.0"
+constraintlayout = "2.1.4"
+cardview = "1.0.0"
+recyclerview = "1.3.0"
+appcompat = "1.6.1"
+mpandroidchart = "v3.1.0"
+okhttp = "4.10.0"
+core-ktx = "1.10.1"
+fragment-ktx = "1.6.0"
+preference-ktx = "1.2.0"
+material = "1.7.0"
+androidx-webkit = "1.7.0"
+androidx-lifecycle-viewmodel-ktx = "2.6.1"
+androidx-lifecycle-runtime-ktx = "2.6.1"
+androidx-security-crypto = "1.1.0-alpha06"
+androidx-annotation = "1.6.0"
+android-gradle-plugin = "8.1.1"
+
+[libraries]
+kotlin = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
+androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
+androidx-cardview = { group = "androidx.cardview", name = "cardview", version.ref = "cardview" }
+androidx-recyclerview = { group = "androidx.recyclerview", name = "recyclerview", version.ref = "recyclerview" }
+androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
+mpandroidchart = { group = "com.github.PhilJay", name = "MPAndroidChart", version.ref = "mpandroidchart" }
+square-okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
+androidx-core-ktx = { group = "androidx.core", name = "core", version.ref = "core-ktx" }
+androidx-fragment-ktx = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "fragment-ktx" }
+androidx-preference-ktx = { group = "androidx.preference", name = "preference-ktx", version.ref = "preference-ktx" }
+material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+androidx-webkit = { group = "androidx.webkit", name = "webkit", version.ref = "androidx-webkit" }
+androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle-viewmodel-ktx" }
+androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "androidx-lifecycle-runtime-ktx" }
+androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "androidx-security-crypto" }
+androidx-annotation = { group = "androidx.annotation", name = "annotation", version.ref = "androidx-annotation" }
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "android-gradle-plugin" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ androidx-security-crypto = "1.1.0-alpha06"
 androidx-constraintlayout = "2.1.4"
 androidx-cardview = "1.0.0"
 androidx-recyclerview = "1.3.0"
+bouncycastle = "1.49"
 mpandroidchart = "v3.1.0"
 kotlin = "1.9.0"
 square-okhttp = "4.10.0"
@@ -38,6 +39,11 @@ androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecyc
 androidx-recyclerview = { group = "androidx.recyclerview", name = "recyclerview", version.ref = "androidx-recyclerview" }
 androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "androidx-security-crypto" }
 mpandroidchart = { group = "com.github.PhilJay", name = "MPAndroidChart", version.ref = "mpandroidchart" }
+org-bouncycastle-bcprov-jdk15on = { group = "org.bouncycastle", name = "bcprov-jdk15on", version.ref = "bouncycastle" }
+org-bouncycastle-bcprov-ext-jdk15on = { group = "org.bouncycastle", name = "bcprov-ext-jdk15on", version.ref = "bouncycastle" }
+org-bouncycastle-bcpkix-jdk15on = { group = "org.bouncycastle", name = "bcpkix-jdk15on", version.ref = "bouncycastle" }
+org-bouncycastle-bcmail-jdk15on = { group = "org.bouncycastle", name = "bcmail-jdk15on", version.ref = "bouncycastle" }
+org-bouncycastle-bcpg-jdk15on = { group = "org.bouncycastle", name = "bcpg-jdk15on", version.ref = "bouncycastle" }
 kotlin = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
 square-okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "square-okhttp" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,7 +45,7 @@ square-okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref =
 androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidx-test-core" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 mockito-core = { group = "org.mockito", name = "mockito-core", version.ref = "mockito-core" }
-robolectric = { group = "org.robolectric:robolectric:4.10.2", name = "robolectric", version.ref = "robolectric" }
+robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "android-gradle-plugin" }

--- a/main/build.gradle.kts
+++ b/main/build.gradle.kts
@@ -233,6 +233,7 @@ dependencies {
     // https://maven.google.com/web/index.html
     implementation(libs.androidx.annotation)
 
+    uiImplementation(libs.android.view.material)
     uiImplementation(libs.androidx.appcompat)
     uiImplementation(libs.androidx.cardview)
     uiImplementation(libs.androidx.constraintlayout)
@@ -245,15 +246,14 @@ dependencies {
     uiImplementation(libs.androidx.security.crypto)
     uiImplementation(libs.androidx.webkit)
     uiImplementation(libs.kotlin)
-    uiImplementation(libs.material)
     uiImplementation(libs.mpandroidchart)
     uiImplementation(libs.square.okhttp)
 
-    testImplementation("androidx.test:core:1.4.0")
-    testImplementation("junit:junit:4.13.2")
+    testImplementation(libs.androidx.test.core)
+    testImplementation(libs.junit)
     testImplementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.21")
-    testImplementation("org.mockito:mockito-core:3.9.0")
-    testImplementation("org.robolectric:robolectric:4.10.2")
+    testImplementation(libs.mockito.core)
+    testImplementation(libs.robolectric)
 }
 
 fun DependencyHandler.uiImplementation(dependencyNotation: Any): Dependency? =

--- a/main/build.gradle.kts
+++ b/main/build.gradle.kts
@@ -232,6 +232,7 @@ android.applicationVariants.all(object : Action<ApplicationVariant> {
 dependencies {
     // https://maven.google.com/web/index.html
     implementation(libs.androidx.annotation)
+    implementation(libs.androidx.core.ktx)
 
     uiImplementation(libs.android.view.material)
     uiImplementation(libs.androidx.appcompat)
@@ -251,7 +252,7 @@ dependencies {
 
     testImplementation(libs.androidx.test.core)
     testImplementation(libs.junit)
-    testImplementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.21")
+    testImplementation(libs.kotlin)
     testImplementation(libs.mockito.core)
     testImplementation(libs.robolectric)
 }

--- a/main/build.gradle.kts
+++ b/main/build.gradle.kts
@@ -231,29 +231,30 @@ android.applicationVariants.all(object : Action<ApplicationVariant> {
 
 dependencies {
     // https://maven.google.com/web/index.html
-
     implementation(libs.androidx.annotation)
 
-    // Is there a nicer way to do this?
-    dependencies.add("uiImplementation", libs.kotlin)
-    dependencies.add("uiImplementation", libs.androidx.appcompat)
-    dependencies.add("uiImplementation", libs.androidx.constraintlayout)
-    dependencies.add("uiImplementation", libs.androidx.cardview)
-    dependencies.add("uiImplementation", libs.androidx.recyclerview)
-    dependencies.add("uiImplementation", libs.androidx.core.ktx)
-    dependencies.add("uiImplementation", libs.androidx.fragment.ktx)
-    dependencies.add("uiImplementation", libs.androidx.preference.ktx)
-    dependencies.add("uiImplementation", libs.androidx.webkit)
-    dependencies.add("uiImplementation", libs.androidx.lifecycle.viewmodel.ktx)
-    dependencies.add("uiImplementation", libs.androidx.lifecycle.runtime.ktx)
-    dependencies.add("uiImplementation", libs.androidx.security.crypto)
-    dependencies.add("uiImplementation", libs.mpandroidchart)
-    dependencies.add("uiImplementation", libs.square.okhttp)
-    dependencies.add("uiImplementation", libs.material)
+    uiImplementation(libs.androidx.appcompat)
+    uiImplementation(libs.androidx.cardview)
+    uiImplementation(libs.androidx.constraintlayout)
+    uiImplementation(libs.androidx.core.ktx)
+    uiImplementation(libs.androidx.fragment.ktx)
+    uiImplementation(libs.androidx.lifecycle.runtime.ktx)
+    uiImplementation(libs.androidx.lifecycle.viewmodel.ktx)
+    uiImplementation(libs.androidx.preference.ktx)
+    uiImplementation(libs.androidx.recyclerview)
+    uiImplementation(libs.androidx.security.crypto)
+    uiImplementation(libs.androidx.webkit)
+    uiImplementation(libs.kotlin)
+    uiImplementation(libs.material)
+    uiImplementation(libs.mpandroidchart)
+    uiImplementation(libs.square.okhttp)
 
-    testImplementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.21")
+    testImplementation("androidx.test:core:1.4.0")
     testImplementation("junit:junit:4.13.2")
+    testImplementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.21")
     testImplementation("org.mockito:mockito-core:3.9.0")
     testImplementation("org.robolectric:robolectric:4.10.2")
-    testImplementation("androidx.test:core:1.4.0")
 }
+
+fun DependencyHandler.uiImplementation(dependencyNotation: Any): Dependency? =
+    add("uiImplementation", dependencyNotation)

--- a/main/build.gradle.kts
+++ b/main/build.gradle.kts
@@ -6,10 +6,9 @@ import com.android.build.gradle.api.ApplicationVariant
  */
 
 plugins {
-    id("com.android.application")
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
     id("checkstyle")
-
-    id("kotlin-android")
 }
 
 android {
@@ -232,36 +231,25 @@ android.applicationVariants.all(object : Action<ApplicationVariant> {
 
 dependencies {
     // https://maven.google.com/web/index.html
-    // https://developer.android.com/jetpack/androidx/releases/core
-    val preferenceVersion = "1.2.0"
-    val coreVersion = "1.10.1"
-    val materialVersion = "1.7.0"
-    val fragment_version = "1.6.0"
 
-
-    implementation("androidx.annotation:annotation:1.6.0")
-    implementation("androidx.core:core:$coreVersion")
-
+    implementation(libs.androidx.annotation)
 
     // Is there a nicer way to do this?
-    dependencies.add("uiImplementation", "androidx.constraintlayout:constraintlayout:2.1.4")
-    dependencies.add("uiImplementation", "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.22")
-    dependencies.add("uiImplementation", "androidx.cardview:cardview:1.0.0")
-    dependencies.add("uiImplementation", "androidx.recyclerview:recyclerview:1.3.0")
-    dependencies.add("uiImplementation", "androidx.appcompat:appcompat:1.6.1")
-    dependencies.add("uiImplementation", "com.github.PhilJay:MPAndroidChart:v3.1.0")
-    dependencies.add("uiImplementation", "com.squareup.okhttp3:okhttp:4.10.0")
-    dependencies.add("uiImplementation", "androidx.core:core:$coreVersion")
-    dependencies.add("uiImplementation", "androidx.core:core-ktx:$coreVersion")
-    dependencies.add("uiImplementation", "androidx.fragment:fragment-ktx:$fragment_version")
-    dependencies.add("uiImplementation", "androidx.preference:preference:$preferenceVersion")
-    dependencies.add("uiImplementation", "androidx.preference:preference-ktx:$preferenceVersion")
-    dependencies.add("uiImplementation", "com.google.android.material:material:$materialVersion")
-    dependencies.add("uiImplementation", "androidx.webkit:webkit:1.7.0")
-    dependencies.add("uiImplementation", "androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1")
-    dependencies.add("uiImplementation", "androidx.lifecycle:lifecycle-runtime-ktx:2.6.1")
-    dependencies.add("uiImplementation","androidx.security:security-crypto:1.1.0-alpha06")
-
+    dependencies.add("uiImplementation", libs.kotlin)
+    dependencies.add("uiImplementation", libs.androidx.appcompat)
+    dependencies.add("uiImplementation", libs.androidx.constraintlayout)
+    dependencies.add("uiImplementation", libs.androidx.cardview)
+    dependencies.add("uiImplementation", libs.androidx.recyclerview)
+    dependencies.add("uiImplementation", libs.androidx.core.ktx)
+    dependencies.add("uiImplementation", libs.androidx.fragment.ktx)
+    dependencies.add("uiImplementation", libs.androidx.preference.ktx)
+    dependencies.add("uiImplementation", libs.androidx.webkit)
+    dependencies.add("uiImplementation", libs.androidx.lifecycle.viewmodel.ktx)
+    dependencies.add("uiImplementation", libs.androidx.lifecycle.runtime.ktx)
+    dependencies.add("uiImplementation", libs.androidx.security.crypto)
+    dependencies.add("uiImplementation", libs.mpandroidchart)
+    dependencies.add("uiImplementation", libs.square.okhttp)
+    dependencies.add("uiImplementation", libs.material)
 
     testImplementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.21")
     testImplementation("junit:junit:4.13.2")

--- a/remoteExample/build.gradle
+++ b/remoteExample/build.gradle
@@ -3,8 +3,9 @@
  * Distributed under the GNU GPL v2 with additional terms. For full terms see the file doc/LICENSE.txt
  */
 
-apply plugin: 'com.android.application'
-
+plugins {
+    alias libs.plugins.android.application
+}
 
 android {
     compileSdkVersion 33

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,22 @@
  * Copyright (c) 2012-2016 Arne Schwabe
  * Distributed under the GNU GPL v2 with additional terms. For full terms see the file doc/LICENSE.txt
  */
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+        maven(url = "https://jitpack.io")
+    }
+}
 
 include(":main")
 include(":tlsexternalcertprovider")

--- a/tlsexternalcertprovider/build.gradle
+++ b/tlsexternalcertprovider/build.gradle
@@ -3,7 +3,9 @@
  * Distributed under the GNU GPL v2 with additional terms. For full terms see the file doc/LICENSE.txt
  */
 
-apply plugin: 'com.android.application'
+plugins {
+    alias libs.plugins.android.application
+}
 
 ext {
     bouncycastleVersion = '1.49'

--- a/tlsexternalcertprovider/build.gradle
+++ b/tlsexternalcertprovider/build.gradle
@@ -58,5 +58,5 @@ dependencies {
     //'org.bouncycastle:bcpg-jdk15on:' + bouncycastleVersion
     )
 
-    testImplementation 'junit:junit:4.12'
+    testImplementation(libs.junit)
 }

--- a/tlsexternalcertprovider/build.gradle
+++ b/tlsexternalcertprovider/build.gradle
@@ -7,13 +7,8 @@ plugins {
     alias libs.plugins.android.application
 }
 
-ext {
-    bouncycastleVersion = '1.49'
-}
-
 android {
     compileSdkVersion 34
-
 
     defaultConfig {
         applicationId "de.blinkt.externalcertprovider"
@@ -51,11 +46,11 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation (
-    //'org.bouncycastle:bcprov-jdk15on:'  + bouncycastleVersion,
-    //'org.bouncycastle:bcprov-ext-jdk15on:' + bouncycastleVersion,
-    //'org.bouncycastle:bcpkix-jdk15on:' + bouncycastleVersion,
-    'org.bouncycastle:bcmail-jdk15on:' + bouncycastleVersion,
-    //'org.bouncycastle:bcpg-jdk15on:' + bouncycastleVersion
+//            libs.org.bouncycastle.bcprov.jdk15on,
+//            libs.org.bouncycastle.bcprov.ext.jdk15on,
+//            libs.org.bouncycastle.bcpkix.jdk15on,
+            libs.org.bouncycastle.bcmail.jdk15on,
+//            libs.org.bouncycastle.bcpg.jdk15on,
     )
 
     testImplementation(libs.junit)


### PR DESCRIPTION
I noticed different versions of Kotlin defined in the build files (`1.6.21` / `1.7.22`/ `1.9.0`) so I decided to consolidate and align project dependencies through the use of [gradle dependency catalog ](https://developer.android.com/build/migrate-to-catalogs) which acts as the source of truth for versions. This should allow for easier addition and management of existing and new dependencies going forward.