### PR TITLE
Fix binding to external authenticator app on Android 14+

### DIFF
--- a/main/src/main/java/de/blinkt/openvpn/core/ExtAuthHelper.java
+++ b/main/src/main/java/de/blinkt/openvpn/core/ExtAuthHelper.java
@@ -215,8 +215,9 @@ public class ExtAuthHelper {
         Intent intent = new Intent(ACTION_CERT_PROVIDER);
         intent.setPackage(packagename);
 
-        if (!context.bindService(intent, extAuthServiceConnection, Context.BIND_AUTO_CREATE)) {
-            throw new KeyChainException("could not bind to external authticator app: " + packagename);
+        if (!context.bindService(intent, extAuthServiceConnection,
+                Context.BIND_AUTO_CREATE | Context.BIND_ALLOW_ACTIVITY_STARTS)) {
+            throw new KeyChainException("could not bind to external authenticator app: " + packagename);
         }
         return new ExternalAuthProviderConnection(context, extAuthServiceConnection, q.take());
     }


### PR DESCRIPTION
External authenticator apps may need to start background activities (for example, to allow users enter a pin code), but starting from Android 14, if the app bound to the service is targeting Android 14 or higher, it no longer allows the app that has the service to start a background activity by default. We need to add flag BIND_ALLOW_ACTIVITY_STARTS to allow the external authenticator app to start background activities.

See docs: https://developer.android.com/guide/components/activities/background-starts#exceptions