### PR TITLE
Add ignorenetworkstate restriction, to allow tunnel over USB

### DIFF
--- a/main/src/main/java/de/blinkt/openvpn/api/AppRestrictions.java
+++ b/main/src/main/java/de/blinkt/openvpn/api/AppRestrictions.java
@@ -14,7 +14,6 @@ import android.text.TextUtils;
 
 import de.blinkt.openvpn.VpnProfile;
 import de.blinkt.openvpn.core.ConfigParser;
-import de.blinkt.openvpn.core.OpenVPNService;
 import de.blinkt.openvpn.core.Preferences;
 import de.blinkt.openvpn.core.ProfileManager;
 import de.blinkt.openvpn.core.VpnStatus;
@@ -145,6 +144,13 @@ public class AppRestrictions {
             boolean pauseVPN = restrictions.getBoolean("screenoffpausevpn");
             SharedPreferences.Editor editor = defaultPrefs.edit();
             editor.putBoolean("screenoff", pauseVPN);
+            editor.apply();
+        }
+        if(restrictions.containsKey("ignorenetworkstate"))
+        {
+            boolean ignoreNetworkState = restrictions.getBoolean("ignorenetworkstate");
+            SharedPreferences.Editor editor = defaultPrefs.edit();
+            editor.putBoolean("ignorenetstate", ignoreNetworkState);
             editor.apply();
         }
         if (restrictions.containsKey("restartvpnonboot"))

--- a/main/src/main/java/de/blinkt/openvpn/core/DeviceStateReceiver.java
+++ b/main/src/main/java/de/blinkt/openvpn/core/DeviceStateReceiver.java
@@ -16,16 +16,11 @@ import android.net.NetworkInfo.State;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
-import android.preference.PreferenceManager;
 
 import de.blinkt.openvpn.R;
 import de.blinkt.openvpn.core.VpnStatus.ByteCountListener;
 
 import java.util.LinkedList;
-import java.util.Objects;
-import java.util.StringTokenizer;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static de.blinkt.openvpn.core.OpenVPNManagement.pauseReason;
 

--- a/main/src/main/res/values/untranslatable.xml
+++ b/main/src/main/res/values/untranslatable.xml
@@ -86,6 +86,7 @@
     <string name="import_from_URL">URL</string>
     <string name="restriction_pausevpn">Pause VPN when screen is off and less than 64 kB transferred data in 60s</string>
     <string name="restriction_restartvpnonboot">Enable the workaround to use an on boot receiver to start the VPN if the Always On VPN functionality is not available</string>
+    <string name="restriction_ignorenetworkstate">Keep the VPN connected even when no network is detected, e.g. when reverse tethering over USB using adb</string>
     <string name="apprest_aidl_list">List of apps that are allowed to use the remote AIDL. If this list is in the restrictions, the app will not allowed any changes to the list by the user. Package names of allowed apps separated by comma, space or newlines</string>
     <string name="apprest_remoteaidl">Remote API access</string>
 

--- a/main/src/main/res/xml/app_restrictions.xml
+++ b/main/src/main/res/xml/app_restrictions.xml
@@ -76,6 +76,10 @@
             android:key="restartvpnonboot"
             android:restrictionType="bool"
             android:title="@string/restriction_restartvpnonboot" />
+    <restriction
+            android:key="ignorenetworkstate"
+            android:restrictionType="bool"
+            android:title="@string/restriction_ignorenetworkstate" />
 
     <restriction
             android:description="@string/apprest_aidl_list"


### PR DESCRIPTION
OpenVPN for Android can be used for reverse tethering (similar to [Gnirehtet](https://github.com/Genymobile/gnirehtet)).

In general, what it requires is:
- ovpn profile with `remote localhost <port>` instruction, so that the client connects to a local tcp port
- Run `adb reverse tcp:<port> tcp:<host_port>` on the host, where `<port>` is the same as above, and `<host_port>` is OpenVPN Server port on the USB host, or another port forward.

One problem with such setup, is that although it does not rely on any physical (e.g. Wi-Fi) network, turning off all such networks will cause tunnel shutdown.

This PR aims to allow changing that default behavior, by setting `ignorenetworkstate` to `false`. This will instruct OpenVPN for Android to keep the tunnel connected also when there is no network.