### PR TITLE
Remove some non-determinism

### DIFF
--- a/main/src/main/cpp/CMakeLists.txt
+++ b/main/src/main/cpp/CMakeLists.txt
@@ -1,4 +1,7 @@
 cmake_minimum_required(VERSION 3.4.1)
+
+add_link_options("LINKER:--build-id=none")
+
 project("ics-openvpn")
 # Git version string
 


### PR DESCRIPTION
Your app is not built reproducible in F-Droid, but we continuously test older versions on https://verification.f-droid.org/ and would like more and more apps to become repro

Looking at the latest app report: https://verification.f-droid.org/packages/de.blinkt.openvpn/

We can remove the build id by adding this to the cmake file

and the timestamp diff block will be fixed on our side once https://gitlab.com/fdroid/fdroidserver/-/merge_requests/1653 gets merged