### PR TITLE
Set BlockUnusedAddressFamilies based of AllowAppVpnBypass

### DIFF
--- a/main/src/main/java/de/blinkt/openvpn/api/ExternalOpenVPNService.java
+++ b/main/src/main/java/de/blinkt/openvpn/api/ExternalOpenVPNService.java
@@ -154,6 +154,7 @@ public class ExternalOpenVPNService extends Service implements StateListener {
         private void updateProfileFromExtras(Bundle extras, VpnProfile vp) {
             if (extras != null) {
                 vp.mAllowAppVpnBypass = extras.getBoolean(EXTRA_INLINE_PROFILE_ALLOW_VPN_BYPASS, false);
+                vp.mBlockUnusedAddressFamilies = !vp.mAllowAppVpnBypass;
                 VpnStatus.logDebug("got extra " + EXTRA_INLINE_PROFILE_ALLOW_VPN_BYPASS + ", mAllowAppVpnBypass=" + vp.mAllowAppVpnBypass);
             }
         }


### PR DESCRIPTION
Currently there is no way to set BlockUnusedAddressFamilies when using Remote API.  
This will set its status based on AllowAppVpnBypass like it is done in Profile Upgrade.