### PR TITLE
Add getDefaultProfile and setDefaultProfile methods to API

### DIFF
--- a/main/src/main/AndroidManifest.xml
+++ b/main/src/main/AndroidManifest.xml
@@ -139,6 +139,10 @@
                 android:name=".api.ResumeVPN"
                 android:exported="true"
                 android:targetActivity=".api.RemoteAction" />
+        <activity-alias
+                android:name=".api.SetDefaultVPN"
+                android:exported="true"
+                android:targetActivity=".api.RemoteAction" />
 
     </application>
 

--- a/main/src/main/aidl/de/blinkt/openvpn/api/IOpenVPNAPIService.aidl
+++ b/main/src/main/aidl/de/blinkt/openvpn/api/IOpenVPNAPIService.aidl
@@ -73,4 +73,10 @@ interface IOpenVPNAPIService {
     * up to now the only extra that can be put is a boolean "de.blinkt.openvpn.api.ALLOW_VPN_BYPASS"
     */
     APIVpnProfile addNewVPNProfileWithExtras (String name, boolean userEditable, String config, in Bundle extras);
+
+    /** Get the current default profile, or null if there is no default */
+    @nullable APIVpnProfile getDefaultProfile();
+
+    /** Set the default profile by UUID */
+    void setDefaultProfile (String profileUUID);
 }

--- a/main/src/main/java/de/blinkt/openvpn/api/APIVpnProfile.java
+++ b/main/src/main/java/de/blinkt/openvpn/api/APIVpnProfile.java
@@ -47,8 +47,8 @@ public class APIVpnProfile implements Parcelable {
         //dest.writeString(mProfileCreator);
     }
 
-    public static final Parcelable.Creator<APIVpnProfile> CREATOR
-            = new Parcelable.Creator<APIVpnProfile>() {
+    public static final Creator<APIVpnProfile> CREATOR
+            = new Creator<APIVpnProfile>() {
         public APIVpnProfile createFromParcel(Parcel in) {
             return new APIVpnProfile(in);
         }

--- a/remoteExample/src/main/aidl/de/blinkt/openvpn/api/IOpenVPNAPIService.aidl
+++ b/remoteExample/src/main/aidl/de/blinkt/openvpn/api/IOpenVPNAPIService.aidl
@@ -18,14 +18,14 @@ interface IOpenVPNAPIService {
 	boolean addVPNProfile (String name, String config);
 	
 	/** start a profile using a config as inline string. Make sure that all needed data is inlined,
-	 * e.g., using <ca>...</ca> or <auth-user-data>...</auth-user-data>
+	 * e.g., using <ca>...</ca> or <auth-user-pass>...</auth-user-pass>
 	 * See the OpenVPN manual page for more on inlining files */
-	void startVPN (String inlineconfig);
+	void startVPN (in String inlineconfig);
 	
 	/** This permission framework is used  to avoid confused deputy style attack to the VPN
 	 * calling this will give null if the app is allowed to use the external API and an Intent
 	 * that can be launched to request permissions otherwise */
-	Intent prepare (String packagename);
+	Intent prepare (in String packagename);
 	
 	/** Used to trigger to the Android VPN permission dialog (VPNService.prepare()) in advance,
 	 * if this return null OpenVPN for ANdroid already has the permissions otherwise you can start the returned Intent
@@ -44,15 +44,15 @@ interface IOpenVPNAPIService {
     /**
       * Registers to receive OpenVPN Status Updates
       */
-    void registerStatusCallback(IOpenVPNStatusCallback cb);
+    void registerStatusCallback(in IOpenVPNStatusCallback cb);
     
     /**
      * Remove a previously registered callback interface.
      */
-    void unregisterStatusCallback(IOpenVPNStatusCallback cb);
+    void unregisterStatusCallback(in IOpenVPNStatusCallback cb);
 
 	/** Remove a profile by UUID */
-	void removeProfile (String profileUUID);
+	void removeProfile (in String profileUUID);
 
 	/** Request a socket to be protected as a VPN socket would be. Useful for creating
 	  * a helper socket for an app controlling OpenVPN
@@ -64,9 +64,19 @@ interface IOpenVPNAPIService {
     /** Use a profile with all certificates etc. embedded */
     APIVpnProfile addNewVPNProfile (String name, boolean userEditable, String config);
 
+    /** Same as startVPN(String), but also takes a Bundle with extra parameters,
+    * which will be applied to the created VPNProfile (e.g. allow vpn bypass). */
+    void startVPNwithExtras(in String inlineconfig, in Bundle extras);
+
     /** Same as addNewVPNProfile(String, boolean, String) but giving possibility to pass a Bundle like
     * in startVPNwithExtras(String, Bundle) to apply e.g. "allow vpn bypass" to profile.
     * up to now the only extra that can be put is a boolean "de.blinkt.openvpn.api.ALLOW_VPN_BYPASS"
     */
     APIVpnProfile addNewVPNProfileWithExtras (String name, boolean userEditable, String config, in Bundle extras);
+
+    /** Get the current default profile, or null if there is no default */
+    @nullable APIVpnProfile getDefaultProfile();
+
+    /** Set the default profile by UUID */
+    void setDefaultProfile (String profileUUID);
 }

--- a/remoteExample/src/main/java/de/blinkt/openvpn/api/APIVpnProfile.java
+++ b/remoteExample/src/main/java/de/blinkt/openvpn/api/APIVpnProfile.java
@@ -1,6 +1,8 @@
 /*
- * Copyright (c) 2012-2015 Arne Schwabe
- * Distributed under the GNU GPL v2 with additional terms. For full terms see the file doc/LICENSE.txt
+ * Copyright (c) 2012-2016 Arne Schwabe
+ * This file is used for implementing the external API and this file like the AIDL and is exempted
+ * from the GPLv2. 
+ *
  */
 
 package de.blinkt.openvpn.api;

--- a/remoteExample/src/main/java/de/blinkt/openvpn/remote/MainFragment.java
+++ b/remoteExample/src/main/java/de/blinkt/openvpn/remote/MainFragment.java
@@ -52,6 +52,7 @@ public class MainFragment extends Fragment implements View.OnClickListener, Hand
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View v = inflater.inflate(R.layout.fragment_main, container, false);
         v.findViewById(R.id.disconnect).setOnClickListener(this);
+        v.findViewById(R.id.setDefaultProfile).setOnClickListener(this);
         v.findViewById(R.id.getMyIP).setOnClickListener(this);
         v.findViewById(R.id.startembedded).setOnClickListener(this);
         v.findViewById(R.id.addNewProfile).setOnClickListener(this);
@@ -70,6 +71,7 @@ public class MainFragment extends Fragment implements View.OnClickListener, Hand
     private static final int MSG_UPDATE_MYIP = 1;
     private static final int START_PROFILE_EMBEDDED = 2;
     private static final int START_PROFILE_BYUUID = 3;
+    private static final int SET_DEFAULT_PROFILE_BYUUID = 4;
     private static final int ICS_OPENVPN_PERMISSION = 7;
     private static final int PROFILE_ADD_NEW = 8;
     private static final int PROFILE_ADD_NEW_EDIT = 9;
@@ -195,9 +197,12 @@ public class MainFragment extends Fragment implements View.OnClickListener, Hand
 
         try {
             List<APIVpnProfile> list = mService.getProfiles();
+            APIVpnProfile defaultProfile = mService.getDefaultProfile();
+            String defaultUUID = defaultProfile != null ? defaultProfile.mUUID : null;
             String all="List:";
             for(APIVpnProfile vp:list.subList(0, Math.min(5, list.size()))) {
-                all = all + vp.mName + ":" + vp.mUUID + "\n";
+                String suffix = (vp.mUUID.equals(defaultUUID)) ? " (default)" : "";
+                all = all + vp.mName + ":" + vp.mUUID + suffix + "\n";
             }
 
             if (list.size() > 5)
@@ -248,6 +253,14 @@ public class MainFragment extends Fragment implements View.OnClickListener, Hand
             case R.id.disconnect:
                 try {
                     mService.disconnect();
+                } catch (RemoteException e) {
+                    // TODO Auto-generated catch block
+                    e.printStackTrace();
+                }
+                break;
+            case R.id.setDefaultProfile:
+                try {
+                    prepareStartProfile(SET_DEFAULT_PROFILE_BYUUID);
                 } catch (RemoteException e) {
                     // TODO Auto-generated catch block
                     e.printStackTrace();
@@ -314,6 +327,12 @@ public class MainFragment extends Fragment implements View.OnClickListener, Hand
             if(requestCode==START_PROFILE_BYUUID)
                 try {
                     mService.startProfile(mStartUUID);
+                } catch (RemoteException e) {
+                    e.printStackTrace();
+                }
+            if(requestCode==SET_DEFAULT_PROFILE_BYUUID)
+                try {
+                    mService.setDefaultProfile(mStartUUID);
                 } catch (RemoteException e) {
                     e.printStackTrace();
                 }

--- a/remoteExample/src/main/res/layout/fragment_main.xml
+++ b/remoteExample/src/main/res/layout/fragment_main.xml
@@ -64,6 +64,14 @@
             android:text="@string/disconnect" />
 
     <Button
+            android:id="@+id/setDefaultProfile"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignBottom="@+id/disconnect"
+            android:layout_toRightOf="@+id/disconnect"
+            android:text="@string/set_default" />
+
+    <Button
             android:id="@+id/startembedded"
             style="?android:attr/buttonStyleSmall"
             android:layout_width="wrap_content"

--- a/remoteExample/src/main/res/values/strings.xml
+++ b/remoteExample/src/main/res/values/strings.xml
@@ -14,6 +14,7 @@
     <string name="no_now">Not now</string>
     <string name="show_my_ip">Show my IP</string>
     <string name="disconnect">Disconnect</string>
+    <string name="set_default">Set Default</string>
     <string name="start_embedded">Start embedded profile</string>
     <string name="addNew">Add new Profile</string>
     <string name="addNewEdit">Add editable profile</string>


### PR DESCRIPTION
- Add `getDefaultProfile` and `setDefaultProfile` API methods and intents.
- Add example usage of both to remoteExample.
- Bring the two copies of `IOpenVPNAPIService.aidl` and of `APIVpnProfile.java` into sync.

Fixes #1857.