### PR TITLE
Add AWS Client VPN SAML authentication support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ idir
 
 test.local.conf
 .kotlin
+
+# Java heap dumps
+*.hprof

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,3 +6,5 @@
 android.nonTransitiveRClass=false
 android.usesSdkInManifest.disallowed=true
 android.newDsl=false
+android.useAndroidX=true
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=512m

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-android-gradle-plugin = "9.0.0"
+android-gradle-plugin = "8.9.1"
 androidx-activity = "1.10.1"
 androidx-annotation = "1.9.1"
 androidx-appcompat = "1.7.1"
@@ -19,6 +19,8 @@ bouncycastle = "1.69"
 mpandroidchart = "v3.1.0"
 kotlin = "2.2.10"
 square-okhttp = "4.10.0"
+androidx-browser = "1.8.0"
+kotlinx-coroutines = "1.8.1"
 
 # Test
 androidx-test-core = "1.7.0"
@@ -51,6 +53,8 @@ org-bouncycastle-bcmail-jdk15on = { group = "org.bouncycastle", name = "bcmail-j
 org-bouncycastle-bcpg-jdk15on = { group = "org.bouncycastle", name = "bcpg-jdk15on", version.ref = "bouncycastle" }
 kotlin = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
 square-okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "square-okhttp" }
+androidx-browser = { group = "androidx.browser", name = "browser", version.ref = "androidx-browser" }
+kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
 
 # Test
 androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidx-test-core" }

--- a/main/build.gradle.kts
+++ b/main/build.gradle.kts
@@ -7,6 +7,7 @@ import com.android.build.gradle.api.ApplicationVariant
 
 plugins {
     alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
     id("checkstyle")
 }
 
@@ -143,6 +144,10 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
     }
 
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
     splits {
         abi {
             isEnable = true
@@ -229,6 +234,7 @@ dependencies {
     // https://maven.google.com/web/index.html
     implementation(libs.androidx.annotation)
     implementation(libs.androidx.core.ktx)
+    implementation(libs.kotlinx.coroutines.android)
 
     uiImplementation(libs.android.view.material)
     uiImplementation(libs.androidx.activity)

--- a/main/src/main/AndroidManifest.xml
+++ b/main/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
         android:label="@string/app"
         android:supportsRtl="true"
         android:theme="@style/blinkt"
+        android:networkSecurityConfig="@xml/network_security_config"
         tools:ignore="UnusedAttribute">
         <meta-data
             android:name="android.content.APP_RESTRICTIONS"

--- a/main/src/main/java/de/blinkt/openvpn/VpnProfile.java
+++ b/main/src/main/java/de/blinkt/openvpn/VpnProfile.java
@@ -92,7 +92,7 @@ public class VpnProfile implements Serializable, Cloneable {
     public static final boolean mIsOpenVPN22 = false;
     private static final long serialVersionUID = 7085688938959334563L;
     private static final int AUTH_RETRY_NONE_KEEP = 1;
-    private static final int AUTH_RETRY_INTERACT = 3;
+    public static final int AUTH_RETRY_INTERACT = 3;
     private static final String EXTRA_RSA_PADDING_TYPE = "de.blinkt.openvpn.api.RSA_PADDING_TYPE";
     private static final String EXTRA_SALTLEN = "de.blinkt.openvpn.api.SALTLEN";
     private static final String EXTRA_NEEDS_DIGEST = "de.blinkt.openvpn.api.NEEDS_DIGEST";
@@ -572,6 +572,8 @@ public class VpnProfile implements Serializable, Cloneable {
         if (isUserPWAuth()) {
             if (mAuthRetry == AUTH_RETRY_NOINTERACT)
                 cfg.append("auth-retry nointeract\n");
+            else if (mAuthRetry == AUTH_RETRY_INTERACT)
+                cfg.append("auth-retry interact\n");
         }
 
         if (!TextUtils.isEmpty(mCrlFilename))

--- a/main/src/main/java/de/blinkt/openvpn/aws/AwsSamlAuthHandler.kt
+++ b/main/src/main/java/de/blinkt/openvpn/aws/AwsSamlAuthHandler.kt
@@ -1,0 +1,165 @@
+/*
+ * Orchestrates the two-phase AWS Client VPN SAML authentication flow:
+ *
+ * Phase 1  — OpenVPN connects with username="N/A", password="ACS::35001".
+ *             The server responds with AUTH_FAILED,CRV1::<flags>::<sid>::<url>.
+ *             The management interface delivers this as:
+ *               >PASSWORD:Verification Failed: 'Auth' ['CRV1:flags:sid:url']
+ *             OpenVpnManagementThread calls AwsSamlAuthHandler.handleCrv1().
+ *
+ * Phase 2  — We start AwsSamlServer on :35001, open the SAML URL in the
+ *             device's default browser, wait for the IdP to POST SAMLResponse
+ *             back to our local server, then update the profile credentials to:
+ *               username = "N/A"
+ *               password = "CRV1::<sid>::<url-encoded-saml-response>"
+ *             and call management.reconnect() so OpenVPN retries auth with
+ *             the real SAML token.
+ */
+package de.blinkt.openvpn.aws
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.util.Log
+import de.blinkt.openvpn.VpnProfile // kept for @Suppress JvmStatic signature
+import de.blinkt.openvpn.core.OpenVPNManagement
+import de.blinkt.openvpn.core.VpnStatus
+import java.net.URLEncoder
+
+private const val TAG = "AwsSamlAuthHandler"
+
+/**
+ * Stateless entry point called from Java.
+ *
+ * The actual work is done on a new background thread so the management
+ * thread is never blocked.
+ */
+object AwsSamlAuthHandler {
+
+    /**
+     * Called by [de.blinkt.openvpn.core.OpenVpnManagementThread] when it
+     * receives an AUTH_FAILED message whose args contain "CRV1:".
+     *
+     * @param context   The [OpenVPNService] (used to launch the browser).
+     * @param management The management thread, used to trigger reconnect.
+     * @param profile   The active [VpnProfile]; credentials are updated in place.
+     * @param args      The raw args string from proccessPWFailed, e.g.
+     *                  " ['CRV1:R,E:abcd1234:https://idp.example.com/saml?...']"
+     */
+    @JvmStatic
+    fun handleCrv1(
+        context: Context,
+        management: OpenVPNManagement,
+        @Suppress("UNUSED_PARAMETER") profile: VpnProfile,
+        args: String
+    ) {
+        Thread({
+            runCrv1Flow(context, management, args)
+        }, "AwsSamlAuthFlow").apply {
+            isDaemon = true
+            start()
+        }
+    }
+
+    // -------------------------------------------------------------------------
+
+    private fun runCrv1Flow(
+        context: Context,
+        management: OpenVPNManagement,
+        args: String
+    ) {
+        val parsed = parseCrv1(args)
+        if (parsed == null) {
+            Log.e(TAG, "Failed to parse CRV1 from args: $args")
+            VpnStatus.logError("AWS SAML: Could not parse CRV1 challenge from server response")
+            return
+        }
+        val (sid, samlUrl) = parsed
+
+        Log.d(TAG, "CRV1 parsed — sid=$sid  url=$samlUrl")
+        VpnStatus.logInfo("AWS SAML: Starting authentication — opening browser")
+
+        val server = AwsSamlServer()
+
+        server.start { result ->
+            when (result) {
+                is SamlResult.Success -> {
+                    Log.d(TAG, "SAMLResponse received, sending credentials")
+                    VpnStatus.logInfo("AWS SAML: Response received, authenticating…")
+
+                    // URL-encode the decoded SAML response to embed it in the
+                    // CRV1 credential string (matches the bash script behaviour).
+                    val encodedSaml = URLEncoder.encode(result.samlResponse, "UTF-8")
+                        .replace("+", "%20") // match Go's url.QueryEscape
+
+                    // OpenVPN is already waiting for credentials on the open
+                    // management socket (auth-retry interact). Send them
+                    // directly — no SIGUSR1/restart needed.
+                    management.sendSamlCredentials("N/A", "CRV1::${sid}::${encodedSaml}")
+                }
+                is SamlResult.Failure -> {
+                    Log.e(TAG, "SAML server error: ${result.error}")
+                    VpnStatus.logError("AWS SAML: Authentication failed — ${result.error}")
+                }
+            }
+        }
+
+        // Open the browser AFTER starting the server so we don't miss the POST.
+        openSamlUrl(context, samlUrl)
+    }
+
+    /**
+     * Parses the CRV1 data from [args].
+     *
+     * Input examples:
+     *   " ['CRV1:R,E:abcd1234:https://idp.example.com/saml']"
+     *   "['CRV1::E:abcd1234:https://idp.example.com/saml']"
+     *
+     * Returns Pair(sessionId, samlUrl) or null on parse failure.
+     *
+     * CRV1 format per OpenVPN spec: CRV1:<flags>:<client_cr>:<challenge_text>
+     * where <challenge_text> is the SAML URL and may itself contain colons.
+     * We split on ":" with limit=4 so everything from field [3] onward is
+     * treated as the URL (preserving "https://...").
+     */
+    private fun parseCrv1(args: String): Pair<String, String>? {
+        val start = args.indexOf("CRV1:")
+        if (start < 0) return null
+
+        // Strip everything up to and including the trailing "']" if present.
+        val raw = args.substring(start).trimEnd('\'', ']', ' ')
+        // raw = "CRV1:R,E:abcd1234:https://..."
+
+        val parts = raw.split(":", limit = 4)
+        if (parts.size < 4) return null
+        // parts[0] = "CRV1"
+        // parts[1] = flags (e.g. "R,E" or empty)
+        // parts[2] = session id
+        // parts[3] = saml URL (e.g. "https://...")
+
+        val sid = parts[2].ifEmpty {
+            Log.w(TAG, "CRV1 session ID is empty")
+            return null
+        }
+
+        // AWS CRV1 has an extra field before the URL: CRV1:flags:sid:b'Ti9B':https://...
+        // With limit=4, parts[3] = "b'Ti9B':https://..." so we find the actual URL.
+        val urlStart = parts[3].indexOf("https://").takeIf { it >= 0 }
+            ?: parts[3].indexOf("http://").takeIf { it >= 0 }
+            ?: 0
+        val url = parts[3].substring(urlStart).ifEmpty {
+            Log.w(TAG, "CRV1 URL is empty")
+            return null
+        }
+
+        return Pair(sid, url)
+    }
+
+    private fun openSamlUrl(context: Context, url: String) {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        context.startActivity(intent)
+        Log.d(TAG, "Opened browser for SAML URL")
+    }
+}

--- a/main/src/main/java/de/blinkt/openvpn/aws/AwsSamlServer.kt
+++ b/main/src/main/java/de/blinkt/openvpn/aws/AwsSamlServer.kt
@@ -1,0 +1,158 @@
+/*
+ * Local HTTP server that listens on 127.0.0.1:35001 for the SAML POST
+ * callback from the AWS Client VPN authentication flow.
+ *
+ * AWS sets the ACS (Assertion Consumer Service) URL to http://127.0.0.1:35001
+ * when we initiate auth with password "ACS::35001". After the user completes
+ * IdP login, the browser is redirected back here with a SAMLResponse POST.
+ */
+package de.blinkt.openvpn.aws
+
+import android.util.Log
+import java.io.ByteArrayOutputStream
+import java.net.InetSocketAddress
+import java.net.ServerSocket
+import java.net.URLDecoder
+
+private const val TAG = "AwsSamlServer"
+private const val SAML_PORT = 35001
+private const val ACCEPT_TIMEOUT_MS = 5 * 60 * 1000 // 5 minutes
+
+/** Result of a SAML callback: either the response or an error. */
+sealed class SamlResult {
+    data class Success(val samlResponse: String) : SamlResult()
+    data class Failure(val error: String) : SamlResult()
+}
+
+/**
+ * Single-use HTTP server that captures one SAML POST then stops.
+ *
+ * Usage:
+ *   val server = AwsSamlServer()
+ *   server.start { result -> ... }
+ *   // later, if needed:
+ *   server.stop()
+ */
+class AwsSamlServer {
+
+    @Volatile private var serverSocket: ServerSocket? = null
+
+    /**
+     * Starts the server on a daemon thread. [onResult] is called exactly once
+     * on that thread with either Success or Failure.
+     */
+    fun start(onResult: (SamlResult) -> Unit) {
+        Thread({
+            try {
+                val ss = ServerSocket()
+                ss.reuseAddress = true
+                ss.soTimeout = ACCEPT_TIMEOUT_MS
+                ss.bind(InetSocketAddress("127.0.0.1", SAML_PORT))
+                serverSocket = ss
+
+                Log.d(TAG, "Listening on 127.0.0.1:$SAML_PORT for SAML POST")
+
+                ss.accept().use { client ->
+                    val saml = readSamlResponse(client.getInputStream())
+                    sendOkResponse(client.getOutputStream())
+                    if (saml != null) {
+                        Log.d(TAG, "Received SAMLResponse (${saml.length} chars)")
+                        onResult(SamlResult.Success(saml))
+                    } else {
+                        onResult(SamlResult.Failure("SAMLResponse field missing from POST body"))
+                    }
+                }
+            } catch (e: Exception) {
+                if (serverSocket?.isClosed == false) {
+                    Log.e(TAG, "Server error", e)
+                    onResult(SamlResult.Failure(e.message ?: "Unknown server error"))
+                }
+                // else: stop() was called intentionally, ignore
+            } finally {
+                serverSocket?.closeQuietly()
+            }
+        }, "AwsSamlServer").apply {
+            isDaemon = true
+            start()
+        }
+    }
+
+    fun stop() {
+        serverSocket?.closeQuietly()
+    }
+
+    // -------------------------------------------------------------------------
+
+    /**
+     * Reads an HTTP POST request from [inputStream] and returns the
+     * URL-decoded value of the "SAMLResponse" form field, or null.
+     */
+    private fun readSamlResponse(inputStream: java.io.InputStream): String? {
+        // Read until the blank line separating headers from body (\r\n\r\n).
+        val headerBuf = ByteArrayOutputStream()
+        val window = ByteArray(4)
+        var windowFilled = 0
+
+        while (true) {
+            val b = inputStream.read()
+            if (b < 0) break
+            headerBuf.write(b)
+            // Slide the 4-byte window
+            if (windowFilled < 4) {
+                window[windowFilled++] = b.toByte()
+            } else {
+                window[0] = window[1]; window[1] = window[2]
+                window[2] = window[3]; window[3] = b.toByte()
+            }
+            // Detect \r\n\r\n
+            if (windowFilled == 4 &&
+                window[0] == '\r'.code.toByte() && window[1] == '\n'.code.toByte() &&
+                window[2] == '\r'.code.toByte() && window[3] == '\n'.code.toByte()
+            ) break
+        }
+
+        val headers = headerBuf.toString(Charsets.UTF_8.name())
+        val contentLength = Regex("Content-Length:\\s*(\\d+)", RegexOption.IGNORE_CASE)
+            .find(headers)?.groupValues?.get(1)?.toIntOrNull() ?: return null
+
+        if (contentLength <= 0) return null
+
+        // Read exactly contentLength bytes for the body.
+        val body = ByteArray(contentLength)
+        var offset = 0
+        while (offset < contentLength) {
+            val read = inputStream.read(body, offset, contentLength - offset)
+            if (read < 0) break
+            offset += read
+        }
+
+        return parseFormParam(String(body, Charsets.UTF_8), "SAMLResponse")
+    }
+
+    /**
+     * Parses [param] out of a URL-encoded form body like
+     * "key1=val1&SAMLResponse=abc%2B...&key2=val2".
+     */
+    private fun parseFormParam(body: String, param: String): String? =
+        body.split("&")
+            .map { it.split("=", limit = 2) }
+            .firstOrNull { it.size == 2 && it[0] == param }
+            ?.get(1)
+            ?.let { URLDecoder.decode(it, "UTF-8") }
+
+    private fun sendOkResponse(out: java.io.OutputStream) {
+        val html = "<html><body>Authentication successful. You may close this tab.</body></html>"
+        val response = buildString {
+            append("HTTP/1.1 200 OK\r\n")
+            append("Content-Type: text/html; charset=UTF-8\r\n")
+            append("Content-Length: ${html.length}\r\n")
+            append("Connection: close\r\n")
+            append("\r\n")
+            append(html)
+        }
+        out.write(response.toByteArray(Charsets.UTF_8))
+        out.flush()
+    }
+
+    private fun ServerSocket.closeQuietly() = try { close() } catch (_: Exception) {}
+}

--- a/main/src/main/java/de/blinkt/openvpn/core/ConfigParser.java
+++ b/main/src/main/java/de/blinkt/openvpn/core/ConfigParser.java
@@ -729,6 +729,15 @@ public class ConfigParser {
             }
         }
 
+        // AWS Client VPN SAML: auth-federate means the real credentials are
+        // obtained via a browser-based SSO flow. Pre-populate the sentinel
+        // values so checkProfile() doesn't prompt for a password before connect.
+        Vector<String> authfederate = getOption("auth-federate", 0, 0);
+        if (authfederate != null) {
+            np.mUsername = "N/A";
+            np.mPassword = "ACS::35001";
+        }
+
         Vector<String> authretry = getOption("auth-retry", 1, 1);
         if (authretry != null) {
             if (authretry.get(1).equals("none"))
@@ -736,7 +745,7 @@ public class ConfigParser {
             else if (authretry.get(1).equals("nointeract"))
                 np.mAuthRetry = VpnProfile.AUTH_RETRY_NOINTERACT;
             else if (authretry.get(1).equals("interact"))
-                np.mAuthRetry = VpnProfile.AUTH_RETRY_NOINTERACT;
+                np.mAuthRetry = VpnProfile.AUTH_RETRY_INTERACT;
             else
                 throw new ConfigParseError("Unknown parameter to auth-retry: " + authretry.get(2));
         }

--- a/main/src/main/java/de/blinkt/openvpn/core/OpenVPNManagement.java
+++ b/main/src/main/java/de/blinkt/openvpn/core/OpenVPNManagement.java
@@ -48,4 +48,11 @@ public interface OpenVPNManagement {
      * @param response  Base64 encoded response
      */
     void sendCRResponse(String response);
+
+    /**
+     * Called by AwsSamlAuthHandler once the SAMLResponse has been received.
+     * Sends the CRV1 phase-2 credentials directly to the waiting OpenVPN
+     * management interface (no SIGUSR1/restart needed).
+     */
+    void sendSamlCredentials(String username, String password);
 }

--- a/main/src/main/java/de/blinkt/openvpn/core/OpenVpnManagementThread.java
+++ b/main/src/main/java/de/blinkt/openvpn/core/OpenVpnManagementThread.java
@@ -41,6 +41,10 @@ public class OpenVpnManagementThread implements Runnable, OpenVPNManagement {
     private LocalServerSocket mServerSocket;
     private boolean mWaitingForRelease = false;
     private long mLastHoldRelease = 0;
+    // True while the AWS SAML browser flow is running (between the CRV1
+    // AUTH_FAILED and the reconnect triggered by AwsSamlAuthHandler).
+    // Prevents responding to auth-retry-interact re-requests during that window.
+    volatile boolean mAwsSamlInProgress = false;
     private LocalSocket mServerSocketLocal;
 
     private pauseReason lastPauseReason = pauseReason.noNetwork;
@@ -695,9 +699,29 @@ public class OpenVpnManagementThread implements Runnable, OpenVPNManagement {
                 pw = mProfile.getPasswordPrivateKey();
                 break;
             case "Auth":
-                pw = mProfile.getPasswordAuth();
-                username = mProfile.mUsername;
-
+                if (isAwsSamlEndpoint(mProfile)) {
+                    if (mProfile.mPassword.startsWith("CRV1::")) {
+                        // Phase 2: AwsSamlAuthHandler has written the CRV1
+                        // token; send it and clear the in-progress flag.
+                        mAwsSamlInProgress = false;
+                        username = mProfile.mUsername;
+                        pw = mProfile.getPasswordAuth();
+                    } else if (mAwsSamlInProgress) {
+                        // auth-retry interact re-asked while SAML browser flow
+                        // is still running. Don't respond — the reconnect()
+                        // SIGUSR1 from AwsSamlAuthHandler will interrupt this
+                        // wait and start a fresh connection cycle.
+                        return;
+                    } else {
+                        // Phase 1: sentinel credentials that tell the AWS
+                        // endpoint our local ACS port for the SAML callback.
+                        username = "N/A";
+                        pw = "ACS::35001";
+                    }
+                } else {
+                    pw = mProfile.getPasswordAuth();
+                    username = mProfile.mUsername;
+                }
                 break;
             case "HTTP Proxy":
                 if (mCurrentProxyConnection != null) {
@@ -722,7 +746,34 @@ public class OpenVpnManagementThread implements Runnable, OpenVPNManagement {
     }
 
     private void proccessPWFailed(String needed, String args) {
+        // AWS Client VPN SAML flow: the server sends back AUTH_FAILED with a
+        // CRV1 challenge that contains a SAML redirect URL and a session ID.
+        // Hand off to our Kotlin handler which starts the local SAML server,
+        // opens the browser, waits for the IdP POST, then reconnects.
+        if (args != null && args.contains("CRV1:")) {
+            mAwsSamlInProgress = true;
+            de.blinkt.openvpn.aws.AwsSamlAuthHandler.handleCrv1(
+                    mOpenVPNService, this, mProfile, args);
+            return;
+        }
         VpnStatus.updateStateString("AUTH_FAILED", needed + args, R.string.state_auth_failed, ConnectionStatus.LEVEL_AUTH_FAILED);
+    }
+
+    /**
+     * Returns true when the VPN profile is an AWS Client VPN endpoint with
+     * SAML/federated authentication. Detected by the well-known AWS Client VPN
+     * hostname pattern: *.clientvpn.*.amazonaws.com
+     */
+    private static boolean isAwsSamlEndpoint(VpnProfile profile) {
+        if (profile == null || profile.mConnections == null) return false;
+        for (Connection conn : profile.mConnections) {
+            if (conn.mServerName != null
+                    && conn.mServerName.contains(".clientvpn.")
+                    && conn.mServerName.contains(".amazonaws.com")) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override
@@ -758,6 +809,18 @@ public class OpenVpnManagementThread implements Runnable, OpenVPNManagement {
     public void reconnect() {
         signalusr1();
         releaseHold();
+    }
+
+    @Override
+    public void sendSamlCredentials(String username, String password) {
+        // OpenVPN is already waiting for credentials on the open management
+        // socket (auth-retry interact re-asked >PASSWORD:Need 'Auth').
+        // Send them directly — no SIGUSR1/restart needed.
+        mAwsSamlInProgress = false;
+        String usercmd = String.format("username 'Auth' %s\n", VpnProfile.openVpnEscape(username));
+        managmentCommand(usercmd);
+        String pwcmd = String.format("password 'Auth' %s\n", VpnProfile.openVpnEscape(password));
+        managmentCommand(pwcmd);
     }
 
     private void processSignCommand(String argument) {

--- a/main/src/main/res/xml/network_security_config.xml
+++ b/main/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Allow cleartext HTTP to 127.0.0.1 only.
+  This is required for the AWS Client VPN SAML callback: after the user
+  authenticates at the IdP, the browser POSTs the SAMLResponse to
+  http://127.0.0.1:35001 — our local AwsSamlServer.
+  All other traffic remains encrypted.
+-->
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">127.0.0.1</domain>
+    </domain-config>
+</network-security-config>

--- a/main/src/ui/java/de/blinkt/openvpn/core/OpenVPNThreadv3.java
+++ b/main/src/ui/java/de/blinkt/openvpn/core/OpenVPNThreadv3.java
@@ -340,6 +340,11 @@ public class OpenVPNThreadv3 extends ClientAPI_OpenVPNClient implements Runnable
     }
 
     @Override
+    public void sendSamlCredentials(String username, String password) {
+        // OpenVPN 3 path — not used for AWS SAML (ovpn23 flavour uses ovpn2 management thread)
+    }
+
+    @Override
     public void log(ClientAPI_LogInfo arg0) {
         String logmsg = arg0.getText();
         while (logmsg.endsWith("\n"))


### PR DESCRIPTION
## What
Adds support for connecting to AWS Client VPN endpoints that use SAML/federated 
authentication (the `auth-federate` directive).

## How it works
Implements the two-phase CRV1 authentication flow described in
https://smallhacks.wordpress.com/2020/07/08/aws-client-vpn-internals/

1. Phase 1 — connects with sentinel credentials (`N/A` / `ACS::35001`)
2. Server responds with `AUTH_FAILED,CRV1:...:https://idp-url`
3. A local HTTP server starts on `127.0.0.1:35001`
4. The SAML URL opens in the device's default browser
5. User logs in via their IdP (Okta, Azure AD, etc.)
6. Browser POSTs `SAMLResponse` back to the local server
7. Phase 2 — credentials sent directly to the waiting OpenVPN management socket

## Changes
- `AwsSamlServer.kt` — single-use local HTTP server for the SAML callback
- `AwsSamlAuthHandler.kt` — orchestrates the two-phase flow
- `OpenVpnManagementThread.java` — intercepts CRV1 challenge, holds auth-retry prompt
- `ConfigParser.java` — detects `auth-federate`, pre-populates sentinel credentials; fixes `auth-retry interact` mapping
- `network_security_config.xml` — allows cleartext HTTP to `127.0.0.1` only

Normal (non-AWS) VPN profiles are completely unaffected.