### PR TITLE
Test build improvements

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,10 +2,15 @@
 name: Build
 permissions:
   contents: read
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   build:
+    env:
+      CI_BRANCH_NAME: ${{ github.ref_name }}
     strategy:
       fail-fast: false
       matrix:
@@ -28,9 +33,9 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
       - name: Build the app
-        run: ./gradlew assemble${{ matrix.target }}Release
+        run: ./gradlew :main:assemble${{ matrix.target }}Release -PciBranchName="${CI_BRANCH_NAME}"
       - name: Run Unit tests
-        run: ./gradlew test${{ matrix.target }}ReleaseUnitTest
+        run: ./gradlew :main:test${{ matrix.target }}DebugUnitTest --info --stacktrace -PciBranchName="${CI_BRANCH_NAME}"
 
       - name: Archive apk artifact
         uses: actions/upload-artifact@v4

--- a/main/build.gradle.kts
+++ b/main/build.gradle.kts
@@ -1,4 +1,7 @@
+@file:Suppress("DEPRECATION")
+
 import com.android.build.gradle.api.ApplicationVariant
+import java.util.Locale
 
 /*
  * Copyright (c) 2012-2016 Arne Schwabe
@@ -10,10 +13,31 @@ plugins {
     id("checkstyle")
 }
 
+fun normalizeBranchForApplicationId(branch: String): String {
+    var normalized = branch.lowercase(Locale.ROOT)
+        .replace(Regex("[^a-z0-9_]"), "_")
+        .replace(Regex("_+"), "_")
+        .trim('_')
+
+    if (normalized.isEmpty())
+        normalized = "branch"
+
+    if (normalized.first().isDigit())
+        normalized = "b$normalized"
+
+    return normalized.take(40)
+}
+
+val ciBranchName = providers.gradleProperty("ciBranchName").orNull
+val isSideBySideCiBuild = !ciBranchName.isNullOrBlank() && ciBranchName != "master"
+val ciBranchApplicationIdSuffix = if (isSideBySideCiBuild) ".ci.${normalizeBranchForApplicationId(ciBranchName!!)}" else null
+val ciBranchLabelSuffix = if (isSideBySideCiBuild) " [${ciBranchName}]" else ""
+
 android {
     buildFeatures {
         aidl = true
         buildConfig = true
+        resValues = true
     }
     namespace = "de.blinkt.openvpn"
     compileSdk = 36
@@ -23,11 +47,15 @@ android {
     ndkVersion = "29.0.14206865"
 
     defaultConfig {
+        applicationId = "de.blinkt.openvpn"
         minSdk = 21
         targetSdk = 36
         //targetSdkPreview = "UpsideDownCake"
         versionCode = 219
         versionName = "0.7.64"
+        if (isSideBySideCiBuild) {
+            resValue("string", "app", "\"OpenVPN for Android${ciBranchLabelSuffix}\"")
+        }
         externalNativeBuild {
             cmake {
                 //arguments+= "-DCMAKE_VERBOSE_MAKEFILE=1"
@@ -127,6 +155,12 @@ android {
     }
 
     buildTypes {
+        all {
+            if (isSideBySideCiBuild) {
+                applicationIdSuffix = ciBranchApplicationIdSuffix
+                versionNameSuffix = "${versionNameSuffix ?: ""}-${normalizeBranchForApplicationId(ciBranchName!!)}"
+            }
+        }
         getByName("release") {
             if (project.hasProperty("icsopenvpnDebugSign")) {
                 logger.warn("property icsopenvpnDebugSign set, using debug signing for release")

--- a/main/src/main/java/de/blinkt/openvpn/LaunchVPN.java
+++ b/main/src/main/java/de/blinkt/openvpn/LaunchVPN.java
@@ -273,7 +273,7 @@ public class LaunchVPN extends Activity {
     void showLogWindow() {
 
         Intent startLW = new Intent();
-        startLW.setComponent(new ComponentName(this, getPackageName() + ".activities.LogWindow"));
+        startLW.setComponent(new ComponentName(this, "de.blinkt.openvpn.activities.LogWindow"));
         startLW.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
         startActivity(startLW);
 


### PR DESCRIPTION
This fix supports installing test builds on a phone without overwriting the normal release app. Those side-by-side test builds use a different applicationId so Android treats them as a separate app, which makes it possible to keep the release install and a test install on the same device at the same time.

Extra changes in build.yaml add the ability to manually trigger GitHub Actions runs