### PR TITLE
Fix server entry proxy when "use system proxy" disabled (OpenVPN v2)

### DIFF
--- a/main/src/main/java/de/blinkt/openvpn/VpnProfile.java
+++ b/main/src/main/java/de/blinkt/openvpn/VpnProfile.java
@@ -742,9 +742,7 @@ public class VpnProfile implements Serializable, Cloneable {
         if (mPushPeerInfo)
             cfg.append("push-peer-info\n");
 
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-        boolean usesystemproxy = prefs.getBoolean("usesystemproxy", true);
-        if (usesystemproxy && !mIsOpenVPN22 && !configForOvpn3 && !usesExtraProxyOptions()) {
+        if (!mIsOpenVPN22 && !configForOvpn3 && !usesExtraProxyOptions()) {
             cfg.append("# Use system proxy setting\n");
             cfg.append("management-query-proxy\n");
         }

--- a/main/src/main/java/de/blinkt/openvpn/core/OpenVpnManagementThread.java
+++ b/main/src/main/java/de/blinkt/openvpn/core/OpenVpnManagementThread.java
@@ -7,6 +7,8 @@ package de.blinkt.openvpn.core;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
 import android.net.LocalServerSocket;
 import android.net.LocalSocket;
 import android.net.LocalSocketAddress;
@@ -456,8 +458,10 @@ public class OpenVpnManagementThread implements Runnable, OpenVPNManagement {
             VpnStatus.logError(String.format(Locale.ENGLISH, "OpenVPN is asking for a proxy of an unknown connection entry (%d)", connectionEntryNumber));
         }
 
-        // atuo detection of proxy
-        if (proxyType == Connection.ProxyType.NONE && mProfile != null) {
+        // auto detection of proxy
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(mOpenVPNService);
+        boolean usesystemproxy = prefs.getBoolean("usesystemproxy", true);
+        if (usesystemproxy && proxyType == Connection.ProxyType.NONE && mProfile != null) {
             SocketAddress proxyaddr = ProxyDetection.detectProxy(mProfile);
             if (proxyaddr instanceof InetSocketAddress) {
                 InetSocketAddress isa = (InetSocketAddress) proxyaddr;


### PR DESCRIPTION
When proxy is configured in the server entry and OpenVPN v2 core is used, proxy is getting ignored unless "Use system proxy" checkbox is also checked.

Add `management-query-proxy` to the config even if no system proxy is used, and move system proxy auto-detection into management socket reply code.