### PR TITLE
refactor(InternalWebView): move postMessage onto a dedicated bridge class

### DIFF
--- a/main/src/ui/java/de/blinkt/openvpn/activities/InternalWebView.kt
+++ b/main/src/ui/java/de/blinkt/openvpn/activities/InternalWebView.kt
@@ -63,32 +63,34 @@ class InternalWebView : BaseActivity() {
 
     }
 
-    @JavascriptInterface
-    fun postMessage(json: String?, transferList: String?): Boolean {
-        val jObejct = JSONObject(json)
+    private inner class AppEventBridge {
+        @JavascriptInterface
+        fun postMessage(json: String?, transferList: String?): Boolean {
+            val jObejct = JSONObject(json)
 
-        val action = jObejct.getString("type")
-        Log.i("OpenVPN,InternalWebview", json + " ---- " + transferList)
+            val action = jObejct.getString("type")
+            Log.i("OpenVPN,InternalWebview", json + " ---- " + transferList)
 
-        if (action == "ACTION_REQUIRED") {
-            // Should show the hidden webview, nothing for us to do
+            if (action == "ACTION_REQUIRED") {
+                // Should show the hidden webview, nothing for us to do
+                return true
+            }
+
+            if (action == "CONNECT_SUCCESS" || action == "CONNECT_FAILED") {
+                runOnUiThread({ finish() })
+            }
+
+            /* runOnUiThread({
+                Toast.makeText(this, json + " ---- " + transferList, Toast.LENGTH_LONG).show()
+            }) */
             return true
         }
-
-        if (action == "CONNECT_SUCCESS" || action == "CONNECT_FAILED") {
-            runOnUiThread({finish()})
-        }
-
-        /* runOnUiThread({
-            Toast.makeText(this, json + " ---- " + transferList, Toast.LENGTH_LONG).show()
-        }) */
-        return true
     }
 
 
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
     private fun attachMessageHandler() {
-        webView.addJavascriptInterface(this, "appEvent")
+        webView.addJavascriptInterface(AppEventBridge(), "appEvent")
     }
 
     override fun onResume() {


### PR DESCRIPTION
Closes #1908.

`InternalWebView.attachMessageHandler()` registers the Activity itself as the appEvent bridge:


`webView.addJavascriptInterface(this, "appEvent")`


and `postMessage` lives on the Activity. Only `@JavascriptInterface`-annotated methods are visible to JS on API 17+, which is well below the project's minSdk, so this is not a runtime regression. The change just narrows what JS can see to a single `AppEventBridge` inner class.

### Change

`postMessage` moves into a private `AppEventBridge` inner class, and `attachMessageHandler` registers a fresh instance instead of `this`. The bridge stays an inner class (not static) because `postMessage` still calls `runOnUiThread { finish() }` against the outer Activity. JS contract is unchanged (`window.appEvent.postMessage(...)`).