### PR TITLE
Add a missing space in `remote_warning` string

### DIFF
--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -270,7 +270,7 @@
     <string name="tls_remote_deprecated">tls-remote (DEPRECATED)</string>
     <string name="help_translate">You can help translating by visiting https://crowdin.net/project/ics-openvpn/invite</string>
     <string name="prompt">%1$s attempts to control %2$s</string>
-    <string name="remote_warning">By proceeding, you are giving the application permission to completely control OpenVPN for Android and to intercept all network traffic.<b>Do NOT accept unless you trust the application.</b> Otherwise, you run the risk of having your data compromised by malicious software."</string>
+    <string name="remote_warning">By proceeding, you are giving the application permission to completely control OpenVPN for Android and to intercept all network traffic. <b>Do NOT accept unless you trust the application.</b> Otherwise, you run the risk of having your data compromised by malicious software."</string>
     <string name="remote_trust">I trust this application.</string>
     <string name="no_external_app_allowed">No app allowed to use external API</string>
     <string name="allowed_apps">Allowed apps: %s</string>


### PR DESCRIPTION
<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/c63386cd-5df8-4264-ae04-2b78fa56e810" />

<!-- Illustrates: [Benjamin_Loison/ics-openvpn/issues/5](https://codeberg.org/Benjamin_Loison/ics-openvpn/issues/5) -->