### PR TITLE
Fix connection duplication

### DIFF
--- a/main/src/main/java/de/blinkt/openvpn/VpnProfile.java
+++ b/main/src/main/java/de/blinkt/openvpn/VpnProfile.java
@@ -870,6 +870,8 @@ public class VpnProfile implements Serializable, Cloneable {
     protected VpnProfile clone() throws CloneNotSupportedException {
         VpnProfile copy = (VpnProfile) super.clone();
         copy.mUuid = UUID.randomUUID();
+        copy.mVersion = 0;
+        copy.changesLog = new Vector<>();
         copy.mConnections = new Connection[mConnections.length];
         int i = 0;
         for (Connection conn : mConnections) {


### PR DESCRIPTION
When duplicating the connection and trying to connect to it, the connection status is updated on the original connection, and oftentimes you receive a spam of "Profile has changed outside the editor. Closing configuration editor" bubbles.

This is due version not being reset.
Also remove configuration changes log.