### PR TITLE
Fix proxy with multiple connections on OpenVPN 3

### DIFF
--- a/main/src/main/java/de/blinkt/openvpn/VpnProfile.java
+++ b/main/src/main/java/de/blinkt/openvpn/VpnProfile.java
@@ -496,7 +496,51 @@ public class VpnProfile implements Serializable, Cloneable {
             if (canUsePlainRemotes) {
                 for (Connection conn : mConnections) {
                     if (conn.mEnabled) {
-                        cfg.append(conn.getConnectionBlock(configForOvpn3));
+                        // For OpenVPN 3, http-proxy cannot be scoped per-remote when using plain
+                        // remote directives (not <connection> blocks). Emit remotes without proxy
+                        // here; a shared global proxy is emitted below if applicable.
+                        cfg.append(conn.getConnectionBlock(configForOvpn3, !configForOvpn3));
+                    }
+                }
+
+                if (configForOvpn3) {
+                    // OpenVPN 3 does not support http-proxy inside <connection> blocks and has no
+                    // management interface for per-remote proxy queries. Emit a single global proxy
+                    // only when ALL enabled connections share exactly the same proxy configuration.
+                    // If any connection differs — including having NONE vs non-NONE proxy — no
+                    // global proxy is emitted, preventing proxy leakage across remotes.
+                    Connection sharedProxy = null;
+                    boolean proxyConsistent = true;
+                    boolean hasNoneProxy = false;
+                    boolean hasNonNoneProxy = false;
+                    for (Connection conn : mConnections) {
+                        if (!conn.mEnabled) continue;
+                        if (conn.mProxyType == Connection.ProxyType.NONE) {
+                            hasNoneProxy = true;
+                        } else {
+                            hasNonNoneProxy = true;
+                            if (sharedProxy == null) {
+                                sharedProxy = conn;
+                            } else if (conn.mProxyType != sharedProxy.mProxyType
+                                    || !conn.mProxyName.equals(sharedProxy.mProxyName)
+                                    || !conn.mProxyPort.equals(sharedProxy.mProxyPort)) {
+                                proxyConsistent = false;
+                                break;
+                            }
+                        }
+                    }
+                    // Only emit global proxy when every enabled connection agrees on the same
+                    // non-NONE proxy. Mixed NONE/non-NONE means we cannot apply any global proxy.
+                    if (sharedProxy != null && proxyConsistent && !hasNoneProxy) {
+                        if (sharedProxy.mProxyType == Connection.ProxyType.HTTP) {
+                            cfg.append(String.format(Locale.US, "http-proxy %s %s\n",
+                                    sharedProxy.mProxyName, sharedProxy.mProxyPort));
+                            if (sharedProxy.mUseProxyAuth) {
+                                cfg.append(String.format(Locale.US,
+                                        "<http-proxy-user-pass>\n%s\n%s\n</http-proxy-user-pass>\n",
+                                        sharedProxy.mProxyAuthUser, sharedProxy.mProxyAuthPassword));
+                            }
+                        }
                     }
                 }
             }

--- a/main/src/main/java/de/blinkt/openvpn/core/Connection.java
+++ b/main/src/main/java/de/blinkt/openvpn/core/Connection.java
@@ -38,6 +38,10 @@ public class Connection implements Serializable, Cloneable {
 
 
     public String getConnectionBlock(boolean isOpenVPN3) {
+        return getConnectionBlock(isOpenVPN3, true);
+    }
+
+    public String getConnectionBlock(boolean isOpenVPN3, boolean includeProxy) {
         String cfg = "";
 
         // Server Address
@@ -53,15 +57,17 @@ public class Connection implements Serializable, Cloneable {
         if (mConnectTimeout != 0)
             cfg += String.format(Locale.US, " connect-timeout  %d\n", mConnectTimeout);
 
-        // OpenVPN 2.x manages proxy connection via management interface
-        if ((isOpenVPN3 || usesExtraProxyOptions()) && mProxyType == ProxyType.HTTP)
-        {
-            cfg+=String.format(Locale.US,"http-proxy %s %s\n", mProxyName, mProxyPort);
-            if (mUseProxyAuth)
-                cfg+=String.format(Locale.US, "<http-proxy-user-pass>\n%s\n%s\n</http-proxy-user-pass>\n", mProxyAuthUser, mProxyAuthPassword);
-        }
-        if (usesExtraProxyOptions() && mProxyType == ProxyType.SOCKS5) {
-            cfg+=String.format(Locale.US,"socks-proxy %s %s\n", mProxyName, mProxyPort);
+        if (includeProxy) {
+            // OpenVPN 2.x manages proxy connection via management interface
+            if ((isOpenVPN3 || usesExtraProxyOptions()) && mProxyType == ProxyType.HTTP)
+            {
+                cfg+=String.format(Locale.US,"http-proxy %s %s\n", mProxyName, mProxyPort);
+                if (mUseProxyAuth)
+                    cfg+=String.format(Locale.US, "<http-proxy-user-pass>\n%s\n%s\n</http-proxy-user-pass>\n", mProxyAuthUser, mProxyAuthPassword);
+            }
+            if (usesExtraProxyOptions() && mProxyType == ProxyType.SOCKS5) {
+                cfg+=String.format(Locale.US,"socks-proxy %s %s\n", mProxyName, mProxyPort);
+            }
         }
 
         if (!TextUtils.isEmpty(mCustomConfiguration) && mUseCustomConfig) {


### PR DESCRIPTION
If several connections are configured in "Server List" tab, and only one of them has proxy, all connections will try to use proxy due to bug in configuration builder.

Add proxy directive only for a connection with proxy configured.